### PR TITLE
[PR] : [fix]: 캘린더 랜더링 문제 해결

### DIFF
--- a/src/shared/components/calendar/personal/CalendarBase.tsx
+++ b/src/shared/components/calendar/personal/CalendarBase.tsx
@@ -26,59 +26,80 @@ const CalendarBase = ({
   const startDay = startOfMonth.day() // 그 달의 1일의 요일 -> 달력에서 1일은 어느 칸에 둘지
   const daysInMonth = currentDate.daysInMonth() // 그 달이 며칠까지 있는지 계산.
 
-  // 날짜 박스 렌더링 함수
-  const renderDays = () => {
-    const days = [] // 날짜 배열
-    // 1일이 시작하기 전까지 '공백' 칸 채우기
-    for (let i = 0; i < startDay; i++) {
-      days.push(<View style={styles.dayBox} key={`empty-${i}`} />)
-    }
-    // 1일부처 마지막 날짜까지 반복해서 박스 생성
-    for (let i = 1; i <= daysInMonth; i++) {
-      const date = startOfMonth.date(i)
-      const weekDay = date.day() // 각 날짜 (i일)의 요일
-      const isToday = dayjs().isSame(date, 'day') // 오늘인지.
-      const isSelected = selectedDate ? selectedDate.isSame(date, 'day') : false // 선택된 날짜인지
+  // 한 주 단위로 구성된 날짜 표시
+  const renderWeeks = () => {
+    const weeks = []
+    const totalSlots = startDay + daysInMonth
+    const totalRows = Math.ceil(totalSlots / 7)
+    let dayCounter = 1
 
-      let textColor = '#000'
-      if (weekDay === 0) textColor = textDanger
-      else if (weekDay === 6) textColor = textInformation
+    for (let row = 0; row < totalRows; row++) {
+      const weekDays = []
 
-      const key = date.format('YYYY-MM-DD') // string 형식
-      const time = calendarData?.[key]?.workTypeName // string 전달
+      for (let col = 0; col < 7; col++) {
+        const index = row * 7 + col
 
-      days.push(
-        <TouchableOpacity
-          activeOpacity={1}
-          onPress={() => onDatePress && onDatePress(date)}
-          style={styles.dayBox}
-          key={`day-${i}`}
-        >
-          <View className="flex gap-[3px]">
-            <View
-              className={`h-[30px] w-[30px] items-center justify-center rounded-radius-max ${
-                isSelected
-                  ? 'bg-border-primary'
-                  : isToday
-                    ? 'bg-surface-gray-subtle1'
-                    : ''
-              } `}
+        if (index < startDay || dayCounter > daysInMonth) {
+          weekDays.push(<View style={styles.dayBox} key={`empty-${index}`} />)
+        } else {
+          const date = startOfMonth.date(dayCounter)
+          const weekDay = date.day()
+          const isToday = dayjs().isSame(date, 'day')
+          const isSelected = selectedDate
+            ? selectedDate.isSame(date, 'day')
+            : false
+
+          let textColor = '#000'
+          if (weekDay === 0) textColor = textDanger
+          else if (weekDay === 6) textColor = textInformation
+
+          const key = date.format('YYYY-MM-DD')
+          const time = calendarData?.[key]?.workTypeName
+
+          weekDays.push(
+            <TouchableOpacity
+              activeOpacity={1}
+              onPress={() => onDatePress && onDatePress(date)}
+              style={styles.dayBox}
+              key={`day-${dayCounter}`}
             >
-              <Text
-                className={`text-text-danger heading-xxxs`}
-                style={[{ color: textColor }, isSelected && { color: 'white' }]}
-              >
-                {i}
-              </Text>
-            </View>
-            <View className="h-[30px]">
-              {time && <TimeFrame text={time} />}
-            </View>
-          </View>
-        </TouchableOpacity>
+              <View className="flex gap-[3px]">
+                <View
+                  className={`h-[30px] w-[30px] items-center justify-center rounded-radius-max ${
+                    isSelected
+                      ? 'bg-border-primary'
+                      : isToday
+                        ? 'bg-surface-gray-subtle1'
+                        : ''
+                  } `}
+                >
+                  <Text
+                    className={`text-text-danger heading-xxxs`}
+                    style={[
+                      { color: textColor },
+                      isSelected && { color: 'white' },
+                    ]}
+                  >
+                    {dayCounter}
+                  </Text>
+                </View>
+                <View className="h-[30px]">
+                  {time && <TimeFrame text={time} />}
+                </View>
+              </View>
+            </TouchableOpacity>
+          )
+          dayCounter++
+        }
+      }
+
+      weeks.push(
+        <View className="flex-row" key={`week-${row}`}>
+          {weekDays}
+        </View>
       )
     }
-    return days
+    return weeks
   }
 
   return (
@@ -104,7 +125,7 @@ const CalendarBase = ({
       </View>
 
       {/* 1, 2, 3 ... */}
-      <View className="flex-row flex-wrap pb-[10px]">{renderDays()}</View>
+      <View className="pb-[10px]">{renderWeeks()}</View>
     </View>
   )
 }

--- a/src/shared/components/calendar/team/TCalendarBase.tsx
+++ b/src/shared/components/calendar/team/TCalendarBase.tsx
@@ -165,7 +165,7 @@ const TCalendarBase = ({
             <Text style={styles.groupText}>3조</Text>
             <Text style={styles.groupText}>4조</Text>
           </View>
-          <View className="flex-row flex-wrap" style={{ flex: 1 }}>
+          <View className="flex-row" style={{ flex: 1 }}>
             {weekDays}
           </View>
         </View>
@@ -210,6 +210,7 @@ export default TCalendarBase
 const styles = StyleSheet.create({
   dayBox: {
     justifyContent: 'center',
+    minHeight: 1,
     width: `${100 / 7}%`,
   },
   groupText: {


### PR DESCRIPTION
## [PR] : [fix]: 캘린더 랜더링 문제 해결


### 🔗 **관련 이슈 (Related Issue):**

- close #이슈번호


### ✍️ **변경 내용 (Description):**
캘린더의 날짜와 요일이 일치하지 않는(밀리는) 현상을 수정했습니다.

**Why:**
 기존 구현에서는 날짜를 flex-wrap을 사용하여 나열했는데, 특정 해상도나 상황에서 소수점 픽셀 연산 오차로 인해 7번째 요일(토요일)이 다음 줄로 줄바꿈되어 일요일처럼 보이는 문제가 발생했습니다. 
또한, 빈 날짜(공백) 컴포넌트가 높이 값을 가지지 않아 레이아웃이 무너지는 현상도 있었습니다.

**How:**

레이아웃 구조 변경: flex-wrap에 의존하는 방식에서, 명시적으로 **주 단위(Row)**로 끊어서 렌더링하는 방식으로 변경하여 줄바꿈 오차를 원천 차단했습니다.
스타일 수정: 빈 날짜 뷰(dayBox)에 minHeight: 1을 추가하여, 내용이 없더라도 공간을 차지하도록 수정했습니다.

### **🛠️ 작업 내용 상세 (Detailed Changes):**
1. src/shared/components/calendar/team/TCalendarBase.tsx flex-wrap 속성 제거
2. dayBox 스타일에 minHeight: 1 추가 (빈 셀 렌더링 보장)
3. src/shared/components/calendar/personal/CalendarBase.tsx renderDays (플랫 리스트) → renderWeeks (주 단위 렌더링) 로 로직 리팩토링
4. flex-wrap 제거 및 주(Week) 단위 View 컨테이너 추가

### **🧪 테스트 방법 (How to Test):**
1. 앱 실행 후 근무 형태 입력 화면(개인/팀 캘린더)으로 진입합니다.
2. 2025년 11월 등 1일이 일요일이 아닌 달로 이동합니다.
3. 1일이 해당 요일에 정확히 위치하는지 확인합니다.
4. 토요일(마지막 열) 날짜가 다음 줄로 밀리지 않고 제 자리에 있는지 확인합니다.

### **📸 스크린샷 / 영상**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-29 at 20 37 49" src="https://github.com/user-attachments/assets/03392338-7c47-4091-8625-ab1642827847" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-29 at 20 38 00" src="https://github.com/user-attachments/assets/9706042d-3b45-4c07-b470-ba6befd17c25" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-29 at 20 39 53" src="https://github.com/user-attachments/assets/e24ebbf3-d32b-4938-898f-a1c1f37a25a8" />


### **🤔 고려 사항 (Considerations - Optional):**
이번 수정은 UI 렌더링 로직에 집중되어 있으며, 데이터 처리 로직은 변경되지 않았습니다.

### ✅ **체크리스트 (Checklist):**

PR을 올리기 전 아래 항목들을 확인해주세요.

- [ ] `main` 브랜치에 직접 푸시하지 않았나요?
- [ ] 모든 변경 사항에 대한 테스트를 수행했나요?
- [ ] 코드 주석이 필요한 부분에 적절히 추가되었나요?
- [ ] 변경으로 인한 새로운 버그가 발생할 가능성은 없나요?
- [ ] 의존성 변경이 필요한 경우 `package.json` 또는 `build.gradle` 등을 업데이트했나요?
