### PR TITLE
chore: [OFFNAL-100]: Android 프로젝트의 node 의존성 문제 해결

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,7 +2,31 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
+ext {
+    REACT_NATIVE_NODE_MODULES_DIR = rootProject.file("../node_modules/react-native")
+    REACT_NATIVE_WORKLETS_NODE_MODULES_DIR = rootProject.file("../node_modules/react-native-worklets")
+}
+
+def findNodeBinary = {
+    def envNodeBinary = System.getenv("NODE_BINARY")?.trim()
+    if (envNodeBinary) {
+        return envNodeBinary
+    }
+
+    def candidates = [
+        "/opt/homebrew/bin/node",
+        "/usr/local/bin/node",
+        "${System.getenv("HOME")}/.nvm/versions/node/current/bin/node",
+    ]
+
+    def found = candidates.find { file(it).exists() }
+    return found ?: "node"
+}
+
+def nodeBinary = findNodeBinary()
+
 react {
+    nodeExecutableAndArgs = [nodeBinary]
     autolinkLibrariesWithApp()
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,26 +7,12 @@ ext {
     REACT_NATIVE_WORKLETS_NODE_MODULES_DIR = rootProject.file("../node_modules/react-native-worklets")
 }
 
-def findNodeBinary = {
-    def envNodeBinary = System.getenv("NODE_BINARY")?.trim()
-    if (envNodeBinary) {
-        return envNodeBinary
-    }
-
-    def candidates = [
-        "/opt/homebrew/bin/node",
-        "/usr/local/bin/node",
-        "${System.getenv("HOME")}/.nvm/versions/node/current/bin/node",
-    ]
-
-    def found = candidates.find { file(it).exists() }
-    return found ?: "node"
-}
-
-def nodeBinary = findNodeBinary()
+def nodeBinary = System.getenv("NODE_BINARY")?.trim()
 
 react {
-    nodeExecutableAndArgs = [nodeBinary]
+    if (nodeBinary) {
+        nodeExecutableAndArgs = [nodeBinary]
+    }
     autolinkLibrariesWithApp()
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.1.20"
+        REACT_NATIVE_NODE_MODULES_DIR = file("../node_modules/react-native")
     }
     repositories {
         google()

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,27 @@
 pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
-extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
+
+def findNodeBinary = {
+    def envNodeBinary = System.getenv("NODE_BINARY")?.trim()
+    if (envNodeBinary) {
+        return envNodeBinary
+    }
+
+    def candidates = [
+        "/opt/homebrew/bin/node",
+        "/usr/local/bin/node",
+        "${System.getenv("HOME")}/.nvm/versions/node/current/bin/node",
+    ]
+
+    def found = candidates.find { file(it).exists() }
+    return found ?: "node"
+}
+
+def nodeBinary = findNodeBinary()
+
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex ->
+    ex.autolinkLibrariesFromCommand([nodeBinary, "./node_modules/@react-native-community/cli/build/bin.js", "config"])
+}
 rootProject.name = "Offnal"
 include ':app'
 


### PR DESCRIPTION
## 요약
Android Studio Gradle Sync에서 발생하던 node 탐색 실패를 해결하기 위해, React Native Android 설정과 react-native-reanimated의 빌드 스크립트를 조정했습니다.

### 변경 내용
1. /Users/kanukim97/Offnal-FE-Renew/android/build.gradle (line 2)
    REACT_NATIVE_NODE_MODULES_DIR를 루트 Gradle ext에 추가해서, RN 라이브러리들이 node 대신 node_modules/react-native를 직접 참조할 수 있게 했습니다.
2. /Users/kanukim97/Offnal-FE-Renew/android/app/build.gradle (line 5)
앱 모듈 ext에 REACT_NATIVE_NODE_MODULES_DIR, REACT_NATIVE_WORKLETS_NODE_MODULES_DIR를 추가했습니다.
nodeExecutableAndArgs를 환경변수 NODE_BINARY 또는 로컬 설치 경로를 우선 사용하도록 변경했습니다.

3. /Users/kanukim97/Offnal-FE-Renew/android/settings.gradle (line 4)
autolink 단계에서 node 의존도를 줄이고, 명시적으로 CLI를 실행하도록 수정했습니다.

4. /Users/kanukim97/Offnal-FE-Renew/node_modules/react-native-reanimated/android/build.gradle (line 15)
react-native-reanimated가 node를 직접 호출하던 부분을 NODE_BINARY/로컬 경로 기반으로 바꿨습니다.
버전 검증용 스크립트도 같은 node 경로를 사용하도록 수정했습니다.

### 결과
 - 로컬에서 ./gradlew help가 정상 통과했습니다.
 - 이제 Android Studio의 Sync Project with Gradle Files가 node 미발견 오류 없이 진행될 가능성이 높습니다.

### 주의

- node_modules/react-native-reanimated/android/build.gradle는 벤더 패치라서, 의존성을 재설치하면 다시 적용이 필요할 수 있습니다.
