### PR TITLE
PR: [OFFNAL-77] [KanuKim97]: 카카오 네이티브 로그인 환경 설정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,6 +27,9 @@ project.ext.envConfigFiles = [
 ]
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
+def kakaoNativeAppKey = project.env.get("KAKAO_NATIVE_APP_KEY") ?: ""
+def kakaoScheme = kakaoNativeAppKey ? "kakao${kakaoNativeAppKey}" : "kakao"
+
 
 android {
     ndkVersion rootProject.ext.ndkVersion
@@ -40,6 +43,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1000101
         versionName "1.0.1"
+        resValue "string", "kakao_app_key", kakaoNativeAppKey
     }
 
     signingConfigs {
@@ -62,14 +66,20 @@ android {
         debug {
             signingConfig signingConfigs.debug
             resValue "string", "app_name", "[Dev] Offnal"
-            manifestPlaceholders = [usesCleartextTraffic: "true"]
+            manifestPlaceholders = [
+                usesCleartextTraffic: "true",
+                kakaoScheme: kakaoScheme,
+            ]
         }
         release {
             signingConfig signingConfigs.release
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             resValue "string", "app_name", "Offnal"
-            manifestPlaceholders = [usesCleartextTraffic: "false"]
+            manifestPlaceholders = [
+                usesCleartextTraffic: "false",
+                kakaoScheme: kakaoScheme,
+            ]
         }
     }
     flavorDimensions "version"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,16 @@
         </intent-filter>
       </activity>
       <activity
+        android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+        android:exported="true">
+        <intent-filter>
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="${kakaoScheme}" android:host="oauth" />
+        </intent-filter>
+      </activity>
+      <activity
         android:name=".PermissionsRationaleActivity"
         android:exported="true">
         <intent-filter>

--- a/ios/Offnal/AppDelegate.swift
+++ b/ios/Offnal/AppDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
+import kakao_login
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -30,6 +31,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     )
 
     return true
+  }
+
+  func application(
+    _ application: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    if kakao_login.RNKakaoLogins.isKakaoTalkLoginUrl(url) {
+      return kakao_login.RNKakaoLogins.handleOpen(url)
+    }
+
+    return false
   }
 }
 

--- a/ios/Offnal/Info.plist
+++ b/ios/Offnal/Info.plist
@@ -22,6 +22,19 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao$(KAKAO_NATIVE_APP_KEY)</string>
+			</array>
+		</dict>
+	</array>
+	<key>KAKAO_APP_KEY</key>
+	<string>$(KAKAO_NATIVE_APP_KEY)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	
@@ -57,6 +70,12 @@
 	<string>근무지 위치 확인을 위해 위치 권한이 필요합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>프로필 사진을 설정하기 위해 사진 라이브러리 접근이 필요합니다.</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>storykompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>RCTNewArchEnabled</key>
 	<true/>
 	<key>UIAppFonts</key>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,6 +4,47 @@ require Pod::Executable.execute_command('node', ['-p',
     "react-native/scripts/react_native_pods.rb",
     {paths: [process.argv[1]]},
   )', __dir__]).strip
+require 'fileutils'
+
+# Xcode 26's stricter clang rejects React Native's pinned fmt 11.0.2.
+# Bump the local third-party podspecs to a compatible fmt release until RN updates its pin.
+def patch_react_native_fmt_versions!
+  fmt_podspec = File.expand_path('../node_modules/react-native/third-party-podspecs/fmt.podspec', __dir__)
+  folly_podspec = File.expand_path('../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec', __dir__)
+
+  version_from = '11.0.2'
+  version_to = '11.1.0'
+
+  {
+    fmt_podspec => version_to,
+    folly_podspec => version_to,
+  }.each do |podspec_path, target_version|
+    next unless File.exist?(podspec_path)
+
+    contents = File.read(podspec_path)
+    next unless contents.include?(version_from)
+
+    updated = contents.gsub(version_from, target_version)
+    File.write(podspec_path, updated) if updated != contents
+  end
+end
+
+# CocoaPods caches local podspec JSON under Pods/Local Podspecs, so clear the stale fmt cache too.
+def clear_stale_react_native_podspec_cache!
+  local_podspecs_dir = File.expand_path('Pods/Local Podspecs', __dir__)
+  return unless Dir.exist?(local_podspecs_dir)
+
+  Dir.glob(File.join(local_podspecs_dir, '*fmt*')).each do |cached_spec|
+    FileUtils.rm_f(cached_spec)
+  end
+
+  Dir.glob(File.join(local_podspecs_dir, '*RCT-Folly*')).each do |cached_spec|
+    FileUtils.rm_f(cached_spec)
+  end
+end
+
+patch_react_native_fmt_versions!
+clear_stale_react_native_podspec_cache!
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,15 +1,32 @@
 PODS:
+  - Alamofire (5.9.1)
   - boost (1.84.0)
   - BVLinearGradient (2.8.3):
     - React-Core
   - DoubleConversion (1.1.6)
   - fast_float (8.0.0)
   - FBLazyVector (0.81.4)
-  - fmt (11.0.2)
+  - fmt (11.1.0)
   - glog (0.3.5)
   - hermes-engine (0.81.4):
     - hermes-engine/Pre-built (= 0.81.4)
   - hermes-engine/Pre-built (0.81.4)
+  - kakao-login (5.4.2):
+    - KakaoSDKAuth (= 2.22.0)
+    - KakaoSDKCommon (= 2.22.0)
+    - KakaoSDKUser (= 2.22.0)
+    - React
+  - KakaoSDKAuth (2.22.0):
+    - KakaoSDKCommon (= 2.22.0)
+  - KakaoSDKCommon (2.22.0):
+    - KakaoSDKCommon/Common (= 2.22.0)
+    - KakaoSDKCommon/Network (= 2.22.0)
+  - KakaoSDKCommon/Common (2.22.0)
+  - KakaoSDKCommon/Network (2.22.0):
+    - Alamofire (~> 5.9.0)
+    - KakaoSDKCommon/Common (= 2.22.0)
+  - KakaoSDKUser (2.22.0):
+    - KakaoSDKAuth (= 2.22.0)
   - lottie-ios (4.5.0)
   - lottie-react-native (7.3.5):
     - boost
@@ -73,20 +90,20 @@ PODS:
     - boost
     - DoubleConversion
     - fast_float (= 8.0.0)
-    - fmt (= 11.0.2)
+    - fmt (= 11.1.0)
     - glog
     - RCT-Folly/Default (= 2024.11.18.00)
   - RCT-Folly/Default (2024.11.18.00):
     - boost
     - DoubleConversion
     - fast_float (= 8.0.0)
-    - fmt (= 11.0.2)
+    - fmt (= 11.1.0)
     - glog
   - RCT-Folly/Fabric (2024.11.18.00):
     - boost
     - DoubleConversion
     - fast_float (= 8.0.0)
-    - fmt (= 11.0.2)
+    - fmt (= 11.1.0)
     - glog
   - RCTDeprecation (0.81.4)
   - RCTRequired (0.81.4)
@@ -2918,6 +2935,7 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
+  - "kakao-login (from `../node_modules/@react-native-seoul/kakao-login`)"
   - lottie-react-native (from `../node_modules/lottie-react-native`)
   - NitroModules (from `../node_modules/react-native-nitro-modules`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -3005,6 +3023,10 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - Alamofire
+    - KakaoSDKAuth
+    - KakaoSDKCommon
+    - KakaoSDKUser
     - lottie-ios
     - SocketRocket
 
@@ -3026,6 +3048,8 @@ EXTERNAL SOURCES:
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-2025-07-07-RNv0.81.0-e0fc67142ec0763c6b6153ca2bf96df815539782
+  kakao-login:
+    :path: "../node_modules/@react-native-seoul/kakao-login"
   lottie-react-native:
     :path: "../node_modules/lottie-react-native"
   NitroModules:
@@ -3192,18 +3216,23 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BVLinearGradient: cb006ba232a1f3e4f341bb62c42d1098c284da70
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 941bef1c8eeabd9fe1f501e30a5220beee913886
-  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
+  fmt: 93a49d76e116cafc52c7d12d5f4713d4c9081ed1
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 35c763d57c9832d0eef764316ca1c4d043581394
+  kakao-login: c7b882cd279ca11f5b3abd15d0e0fcb41a427108
+  KakaoSDKAuth: 569b377eda622d93d4575240b8031cd658163eef
+  KakaoSDKCommon: d57127c339fc79e73aa8b236a4c77211c29924f1
+  KakaoSDKUser: 043bcd7e91454ebf3bf64f150c430e6f65f0a08d
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 691b8363e8c591fb78a78254ff2517258891456b
   NitroModules: dae5a0f5867aa19ca3222084519c30cb6ca0280a
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: e25aed0295ba990e1023572290d2a12e8699c6d1
   RCTDeprecation: c0ed3249a97243002615517dff789bf4666cf585
   RCTRequired: 58719f5124f9267b5f9649c08bf23d9aea845b23
   RCTTypeSafety: 4aefa8328ab1f86da273f08517f1f6b343f6c2cc
@@ -3285,6 +3314,6 @@ SPEC CHECKSUMS:
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: a3ed390a19db0459bd6839823a6ac6d9c6db198d
 
-PODFILE CHECKSUM: 8c27cd5d925400a0d7626531808666c3b0551efa
+PODFILE CHECKSUM: 87e6bc4f61900b825bd93d5c7d2d5ce4cea7b488
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@kingstinct/react-native-healthkit": "^11.1.1",
         "@react-native-community/datetimepicker": "^9.0.0",
         "@react-native-cookies/cookies": "^6.2.1",
+        "@react-native-seoul/kakao-login": "^5.4.2",
         "@react-native/new-app-screen": "0.81.4",
         "@react-navigation/bottom-tabs": "^7.4.8",
         "@react-navigation/native": "^7.1.18",
@@ -4359,6 +4360,19 @@
         "react-native": ">= 0.60.2"
       }
     },
+    "node_modules/@react-native-seoul/kakao-login": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@react-native-seoul/kakao-login/-/kakao-login-5.4.2.tgz",
+      "integrity": "sha512-7uaJYo3VW6dey1pLqI8w+fHpd0AWBDe/dffhFKSjN0Dp0R1kgVRlZHHWthzqdqDTDe+AIlDOR8ORm5twpCrsqA==",
+      "license": "MIT",
+      "dependencies": {
+        "dooboolab-welcome": "^1.3.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.81.4",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.4.tgz",
@@ -7801,6 +7815,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dooboolab-welcome": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dooboolab-welcome/-/dooboolab-welcome-1.3.2.tgz",
+      "integrity": "sha512-2NbMaIIURElxEf/UAoVUFlXrO+7n/FRhLCiQlk4fkbGRh9cJ3/f8VEMPveR9m4Ug2l2Zey+UCXjd6EcBqHJ5bw==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "bin": {
+        "dooboolab-welcome": "bin/hello.js"
       }
     },
     "node_modules/dot-case": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "android:dev": "react-native run-android --mode=developdebug",
     "android:prod": "react-native run-android --mode=productrelease",
-    "ios:dev": "react-native run-ios --scheme Development",
-    "ios:prod": "react-native run-ios --scheme Production",
+    "ios:dev": "react-native run-ios --scheme Development --no-packager",
+    "ios:prod": "react-native run-ios --scheme Production --no-packager",
     "lint": "eslint .",
     "start": "react-native start",
     "test": "jest",
@@ -24,6 +24,7 @@
     "@kingstinct/react-native-healthkit": "^11.1.1",
     "@react-native-community/datetimepicker": "^9.0.0",
     "@react-native-cookies/cookies": "^6.2.1",
+    "@react-native-seoul/kakao-login": "^5.4.2",
     "@react-native/new-app-screen": "0.81.4",
     "@react-navigation/bottom-tabs": "^7.4.8",
     "@react-navigation/native": "^7.1.18",

--- a/src/shared/@types/env.d.tsx
+++ b/src/shared/@types/env.d.tsx
@@ -2,6 +2,7 @@ declare module '@env' {
   export const API_URL: string
   export const OPEN_API_URL: string
   export const OPEN_API_SERVICE_KEY: string
+  export const KAKAO_NATIVE_APP_KEY: string
   export const KAKAO_REDIRECT_URI: string
   export const TERMS_OF_USE_URL: string
   export const PRIVACY_POLICY_URL: string


### PR DESCRIPTION
## Summary
 - @react-native-seoul/kakao-login을 사용할 수 있도록 Android/iOS 네이티브 설정을 추가했습니다.
 - Xcode 26.4 환경에서 발생하던 iOS 빌드 이슈를 fmt / RCT-Folly 버전 조정으로 해결했습니다.
 - ios:dev 실행 흐름에서 packager 자동 실행 문제를 줄이도록 iOS 실행 스크립트를 정리했습니다.


## Changes
 - Android에 Kakao callback 처리용 activity와 app key 주입 설정을 추가했습니다.
 - iOS에 Kakao URL scheme, app key, callback URL forwarding 설정을 추가했습니다.
 - Kakao Native App Key를 타입 레벨에서도 사용할 수 있도록 env 타입 정의를 보강했습니다.
 - Kakao native SDK 의존성 반영에 맞춰 lockfile을 갱신했습니다.
 - React Native가 고정하고 있던 fmt 11.0.2를 11.1.0으로 올리고, CocoaPods의 stale cache도 함께 정리하도록 했습니다.
 - `ios:dev` / `ios:prod` 스크립트를 `--no-packager`로 변경했습니다.


## Validation
 - `pod install`
 - `pod update fmt RCT-Folly --no-repo-update`
 - `npm run ios:dev`


## Notes
 - 현재 PR은 native SDK를 바로 사용할 수 있는 플랫폼 및 빌드 기반을 준비하는 작업입니다.
 - 로그인 버튼의 JS 진입점 전환은 후속 작업으로 이어갈 수 있습니다.