### PR TITLE
chore: [OFFNAL-150] [KanuKim97]: 버전 분기 방식 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/🚀-deploy.md
+++ b/.github/ISSUE_TEMPLATE/🚀-deploy.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ## **이슈 제목:** `[날짜] - [환경] - [버전] 배포 시 발생한 [문제 유형]`
 
-**예시:** 2025-07-01 - Production - v1.2.3 배포 시 DB 마이그레이션 실패
+**예시:** 2025-07-01 - Production - v2026.04.001 배포 시 DB 마이그레이션 실패
 
 ## 배포 설명 
 배포 설명을 작성해주세요.
@@ -24,7 +24,7 @@ assignees: ''
 
 * **배포 환경:** `[Production / Staging / Development 등]`
 * **배포 대상 서비스/시스템:** `[예: 백엔드 API 서버, 프론트엔드 웹, 모바일 앱 등]`
-* **배포 버전:** `[예: v1.2.3, git hash: abcdefg]`
+* **배포 버전:** `[예: v2026.04.001, git hash: abcdefg]`
 * **배포 브랜치:** `[예: release/v1.2.3, main, develop]`
 * **배포 도구/플랫폼:** `[예: Jenkins, CircleCI, Kubernetes, AWS CodeDeploy 등]`
 * **배포 시작 시간:** `[예: 2025-07-01 10:30 KST]`

--- a/.github/workflows/Develop_CI.yml
+++ b/.github/workflows/Develop_CI.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
+      - name: Check app version consistency
+        run: npm run version:check
+
       - name: Run ESLint
         continue-on-error: true
         run: npm run lint

--- a/.github/workflows/Release_CI.yml
+++ b/.github/workflows/Release_CI.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
+      - name: Check app version consistency
+        run: npm run version:check
+
       - name: Set up JDK Version 17
         uses: actions/setup-java@v4
         with:
@@ -60,6 +63,9 @@ jobs:
 
       - name: Install JS dependencies
         run: npm ci
+
+      - name: Check app version consistency
+        run: npm run version:check
 
       - name: Set up Ruby (with cache)
         uses: ruby/setup-ruby@v1

--- a/__mocks__/react-native-sqlite-storage.js
+++ b/__mocks__/react-native-sqlite-storage.js
@@ -1,0 +1,9 @@
+const executeSql = jest.fn(async () => [[], []])
+
+module.exports = {
+  enablePromise: jest.fn(),
+  openDatabase: jest.fn(async () => ({
+    executeSql,
+  })),
+  __executeSql: executeSql,
+}

--- a/__tests__/appVersion.test.ts
+++ b/__tests__/appVersion.test.ts
@@ -1,0 +1,30 @@
+import versionConfig from '../version.json'
+import packageJson from '../package.json'
+import appVersion from '../src/shared/config/appVersion'
+
+describe('appVersion', () => {
+  it('derives the marketing version from version.json', () => {
+    expect(appVersion.yearMonth).toBe(versionConfig.yearMonth)
+    expect(appVersion.buildNumber).toBe(versionConfig.buildNumber)
+    expect(appVersion.marketingVersion).toBe(
+      `${versionConfig.yearMonth}.${String(versionConfig.buildNumber).padStart(
+        3,
+        '0'
+      )}`
+    )
+  })
+
+  it('derives the build code from the year.month and build number', () => {
+    const [yearPart, monthPart] = versionConfig.yearMonth.split('.')
+    const year = Number(yearPart)
+    const month = Number(monthPart)
+
+    expect(packageJson.version).toBe(
+      `${year}.${month}.${versionConfig.buildNumber}`
+    )
+
+    expect(appVersion.versionCode).toBe(
+      year * 100000 + month * 1000 + versionConfig.buildNumber
+    )
+  })
+})

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ if (appBuildNumber < 1 || appBuildNumber > 999) {
     throw new GradleException("Invalid buildNumber in version.json: ${appBuildNumber}")
 }
 
-def appVersionName = "${appYearMonth}.${appBuildNumber}"
+def appVersionName = "${appYearMonth}.${appBuildNumber.toString().padLeft(3, '0')}"
 def versionParts = appYearMonth.split("\\.")
 def appVersionCode = versionParts[0].toInteger() * 100000 +
         versionParts[1].toInteger() * 1000 +

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,4 @@
+import groovy.json.JsonSlurper
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
@@ -29,6 +30,29 @@ apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.grad
 
 def kakaoNativeAppKey = project.env.get("KAKAO_NATIVE_APP_KEY") ?: ""
 def kakaoScheme = kakaoNativeAppKey ? "kakao${kakaoNativeAppKey}" : "kakao"
+def versionConfigFile = rootProject.file("../version.json")
+
+if (!versionConfigFile.exists()) {
+    throw new GradleException("Missing version.json at ${versionConfigFile}")
+}
+
+def versionConfig = new JsonSlurper().parse(versionConfigFile)
+def appYearMonth = versionConfig.yearMonth?.toString()
+def appBuildNumber = (versionConfig.buildNumber as Number).intValue()
+
+if (!(appYearMonth ==~ /\d{4}\.\d{2}/)) {
+    throw new GradleException("Invalid yearMonth in version.json: ${appYearMonth}")
+}
+
+if (appBuildNumber < 1 || appBuildNumber > 999) {
+    throw new GradleException("Invalid buildNumber in version.json: ${appBuildNumber}")
+}
+
+def appVersionName = "${appYearMonth}.${appBuildNumber}"
+def versionParts = appYearMonth.split("\\.")
+def appVersionCode = versionParts[0].toInteger() * 100000 +
+        versionParts[1].toInteger() * 1000 +
+        appBuildNumber
 
 android {
     ndkVersion rootProject.ext.ndkVersion
@@ -40,8 +64,8 @@ android {
         applicationId "com.shifterz.offnal"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1000101
-        versionName "1.0.1"
+        versionCode appVersionCode
+        versionName appVersionName
         resValue "string", "kakao_app_key", kakaoNativeAppKey
     }
 

--- a/ios/Offnal.xcodeproj/project.pbxproj
+++ b/ios/Offnal.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 				CODE_SIGN_ENTITLEMENTS = Offnal/Offnal.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = "$(OFFNAL_VERSION_CODE)";
 				DEVELOPMENT_TEAM = 8CG24965GX;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Offnal/Info.plist;
@@ -332,8 +332,8 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
-				"MARKETING_VERSION[sdk=iphoneos*]" = 1.0.0;
+				MARKETING_VERSION = "$(OFFNAL_MARKETING_VERSION)";
+				"MARKETING_VERSION[sdk=iphoneos*]" = "$(OFFNAL_MARKETING_VERSION)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -362,7 +362,7 @@
 				CODE_SIGN_ENTITLEMENTS = Offnal/Offnal.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = "$(OFFNAL_VERSION_CODE)";
 				DEVELOPMENT_TEAM = 8CG24965GX;
 				INFOPLIST_FILE = Offnal/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Offnal;
@@ -372,8 +372,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
-				"MARKETING_VERSION[sdk=iphoneos*]" = 1.0.0;
+				MARKETING_VERSION = "$(OFFNAL_MARKETING_VERSION)";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/Offnal.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
+++ b/ios/Offnal.xcodeproj/xcshareddata/xcschemes/Development.xcscheme
@@ -11,7 +11,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "echo &quot;env/.env.development&quot; &gt; /tmp/envfile&#10;export ENVFILE=&quot;env/.env.development&quot;&#10;cp &quot;${PROJECT_DIR}/../env/.env.development&quot; &quot;${PROJECT_DIR}/../.env&quot;&#10;&#10;&quot;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb&quot; &quot;${SRCROOT}/..&quot; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;">
+               scriptText = "echo &quot;env/.env.development&quot; &gt; /tmp/envfile&#10;export ENVFILE=&quot;env/.env.development&quot;&#10;cp &quot;${PROJECT_DIR}/../env/.env.development&quot; &quot;${PROJECT_DIR}/../.env&quot;&#10;&#10;&quot;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb&quot; &quot;${SRCROOT}/..&quot; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;node &quot;${SRCROOT}/../scripts/version.js&quot; xcconfig &gt;&gt; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/Offnal.xcodeproj/xcshareddata/xcschemes/Production.xcscheme
+++ b/ios/Offnal.xcodeproj/xcshareddata/xcschemes/Production.xcscheme
@@ -11,7 +11,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "echo &quot;env/.env.production&quot; &gt; /tmp/envfile&#10;export ENVFILE=&quot;env/.env.production&quot;&#10;cp &quot;${PROJECT_DIR}/../env/.env.production&quot; &quot;${PROJECT_DIR}/../.env&quot;&#10;&#10;&quot;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb&quot; &quot;${SRCROOT}/..&quot; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;">
+               scriptText = "echo &quot;env/.env.production&quot; &gt; /tmp/envfile&#10;export ENVFILE=&quot;env/.env.production&quot;&#10;cp &quot;${PROJECT_DIR}/../env/.env.production&quot; &quot;${PROJECT_DIR}/../.env&quot;&#10;&#10;&quot;${SRCROOT}/../node_modules/react-native-config/ios/ReactNativeConfig/BuildXCConfig.rb&quot; &quot;${SRCROOT}/..&quot; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;node &quot;${SRCROOT}/../scripts/version.js&quot; xcconfig &gt;&gt; &quot;${SRCROOT}/tmp.xcconfig&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios/Offnal/Info.plist
+++ b/ios/Offnal/Info.plist
@@ -97,8 +97,7 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "offnal",
-  "version": "1.0.0",
+  "version": "2026.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "offnal",
-      "version": "1.0.0",
+      "version": "2026.4.1",
       "dependencies": {
         "@gorhom/bottom-sheet": "^5.2.6",
         "@invertase/react-native-apple-authentication": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "offnal",
-  "version": "1.0.0",
+  "version": "2026.4.1",
   "private": true,
   "scripts": {
     "android:dev": "react-native run-android --mode=developdebug",
@@ -8,6 +8,8 @@
     "ios:dev": "react-native run-ios --scheme Development",
     "ios:prod": "react-native run-ios --scheme Production",
     "lint": "eslint .",
+    "version:check": "node scripts/version.js check",
+    "version:sync": "node scripts/version.js sync",
     "start": "react-native start",
     "test": "jest",
     "prepare": "husky"

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -2,11 +2,17 @@
 
 const fs = require('fs')
 const path = require('path')
+const {
+  getVersionSnapshot,
+  validateVersionConfig,
+  formatMarketingVersion,
+  formatPackageVersion,
+  formatVersionCode,
+} = require('../src/shared/config/versionUtils')
 
 const VERSION_FILE_PATH = path.join(__dirname, '..', 'version.json')
 const PACKAGE_JSON_PATH = path.join(__dirname, '..', 'package.json')
 const PACKAGE_LOCK_PATH = path.join(__dirname, '..', 'package-lock.json')
-const VERSION_MONTH_PATTERN = /^\d{4}\.\d{2}$/
 
 function getKstYearMonth(date = new Date()) {
   const formatter = new Intl.DateTimeFormat('en-CA', {
@@ -41,73 +47,6 @@ function readJsonFile(filePath) {
 
 function writeJsonFile(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`)
-}
-
-function validateVersionConfig(versionConfig) {
-  const yearMonth = String(versionConfig.yearMonth ?? '')
-  const buildNumber = Number(versionConfig.buildNumber)
-
-  if (!VERSION_MONTH_PATTERN.test(yearMonth)) {
-    throw new Error(
-      `Invalid yearMonth "${yearMonth}". Expected the format YYYY.MM.`
-    )
-  }
-
-  if (!Number.isInteger(buildNumber) || buildNumber < 1 || buildNumber > 999) {
-    throw new Error(
-      `Invalid buildNumber "${versionConfig.buildNumber}". Expected an integer between 1 and 999.`
-    )
-  }
-
-  return {
-    yearMonth,
-    buildNumber,
-  }
-}
-
-function formatMarketingVersion(yearMonth, buildNumber) {
-  return `${yearMonth}.${String(buildNumber).padStart(3, '0')}`
-}
-
-function formatPackageVersion(yearMonth, buildNumber) {
-  const [yearPart, monthPart] = yearMonth.split('.')
-  const year = Number(yearPart)
-  const month = Number(monthPart)
-
-  if (!Number.isInteger(year) || !Number.isInteger(month)) {
-    throw new Error(`Invalid yearMonth "${yearMonth}"`)
-  }
-
-  return `${year}.${month}.${buildNumber}`
-}
-
-function formatVersionCode(yearMonth, buildNumber) {
-  const [yearPart, monthPart] = yearMonth.split('.')
-  const year = Number(yearPart)
-  const month = Number(monthPart)
-
-  if (!Number.isInteger(year) || !Number.isInteger(month)) {
-    throw new Error(`Invalid yearMonth "${yearMonth}"`)
-  }
-
-  return year * 100000 + month * 1000 + buildNumber
-}
-
-function getVersionSnapshot(versionConfig) {
-  const validated = validateVersionConfig(versionConfig)
-
-  return {
-    ...validated,
-    marketingVersion: formatMarketingVersion(
-      validated.yearMonth,
-      validated.buildNumber
-    ),
-    packageVersion: formatPackageVersion(
-      validated.yearMonth,
-      validated.buildNumber
-    ),
-    versionCode: formatVersionCode(validated.yearMonth, validated.buildNumber),
-  }
 }
 
 function writeVersionConfig(filePath, versionConfig) {

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const VERSION_FILE_PATH = path.join(__dirname, '..', 'version.json')
+const PACKAGE_JSON_PATH = path.join(__dirname, '..', 'package.json')
+const PACKAGE_LOCK_PATH = path.join(__dirname, '..', 'package-lock.json')
+const VERSION_MONTH_PATTERN = /^\d{4}\.\d{2}$/
+
+function getKstYearMonth(date = new Date()) {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+  })
+
+  const parts = formatter.formatToParts(date)
+  const year = parts.find(part => part.type === 'year')?.value
+  const month = parts.find(part => part.type === 'month')?.value
+
+  if (!year || !month) {
+    throw new Error('Failed to resolve the current KST year.month value.')
+  }
+
+  return `${year}.${month}`
+}
+
+function readVersionConfig(filePath = VERSION_FILE_PATH) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing version config: ${filePath}`)
+  }
+
+  const parsed = readJsonFile(filePath)
+  return validateVersionConfig(parsed)
+}
+
+function readJsonFile(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function writeJsonFile(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function validateVersionConfig(versionConfig) {
+  const yearMonth = String(versionConfig.yearMonth ?? '')
+  const buildNumber = Number(versionConfig.buildNumber)
+
+  if (!VERSION_MONTH_PATTERN.test(yearMonth)) {
+    throw new Error(
+      `Invalid yearMonth "${yearMonth}". Expected the format YYYY.MM.`
+    )
+  }
+
+  if (!Number.isInteger(buildNumber) || buildNumber < 1 || buildNumber > 999) {
+    throw new Error(
+      `Invalid buildNumber "${versionConfig.buildNumber}". Expected an integer between 1 and 999.`
+    )
+  }
+
+  return {
+    yearMonth,
+    buildNumber,
+  }
+}
+
+function formatMarketingVersion(yearMonth, buildNumber) {
+  return `${yearMonth}.${String(buildNumber).padStart(3, '0')}`
+}
+
+function formatPackageVersion(yearMonth, buildNumber) {
+  const [yearPart, monthPart] = yearMonth.split('.')
+  const year = Number(yearPart)
+  const month = Number(monthPart)
+
+  if (!Number.isInteger(year) || !Number.isInteger(month)) {
+    throw new Error(`Invalid yearMonth "${yearMonth}"`)
+  }
+
+  return `${year}.${month}.${buildNumber}`
+}
+
+function formatVersionCode(yearMonth, buildNumber) {
+  const [yearPart, monthPart] = yearMonth.split('.')
+  const year = Number(yearPart)
+  const month = Number(monthPart)
+
+  if (!Number.isInteger(year) || !Number.isInteger(month)) {
+    throw new Error(`Invalid yearMonth "${yearMonth}"`)
+  }
+
+  return year * 100000 + month * 1000 + buildNumber
+}
+
+function getVersionSnapshot(versionConfig) {
+  const validated = validateVersionConfig(versionConfig)
+
+  return {
+    ...validated,
+    marketingVersion: formatMarketingVersion(
+      validated.yearMonth,
+      validated.buildNumber
+    ),
+    packageVersion: formatPackageVersion(
+      validated.yearMonth,
+      validated.buildNumber
+    ),
+    versionCode: formatVersionCode(validated.yearMonth, validated.buildNumber),
+  }
+}
+
+function writeVersionConfig(filePath, versionConfig) {
+  writeJsonFile(filePath, versionConfig)
+}
+
+function syncPackageJsonVersion(snapshot, filePath = PACKAGE_JSON_PATH) {
+  const packageJson = readJsonFile(filePath)
+  packageJson.version = snapshot.packageVersion
+  writeJsonFile(filePath, packageJson)
+  return packageJson.version
+}
+
+function syncPackageLockVersion(snapshot, filePath = PACKAGE_LOCK_PATH) {
+  if (!fs.existsSync(filePath)) {
+    return null
+  }
+
+  const packageLock = readJsonFile(filePath)
+  packageLock.version = snapshot.packageVersion
+
+  if (packageLock.packages?.['']) {
+    packageLock.packages[''].version = snapshot.packageVersion
+  }
+
+  writeJsonFile(filePath, packageLock)
+  return packageLock.version
+}
+
+function syncVersionYearMonth(filePath = VERSION_FILE_PATH) {
+  const versionConfig = readVersionConfig(filePath)
+  const nextVersionConfig = {
+    ...versionConfig,
+    yearMonth: getKstYearMonth(),
+  }
+
+  writeVersionConfig(filePath, nextVersionConfig)
+  const snapshot = getVersionSnapshot(nextVersionConfig)
+  syncPackageJsonVersion(snapshot)
+  syncPackageLockVersion(snapshot)
+  return snapshot
+}
+
+function checkVersionConfig(filePath = VERSION_FILE_PATH) {
+  const current = readVersionConfig(filePath)
+  const snapshot = getVersionSnapshot(current)
+  const currentYearMonth = getKstYearMonth()
+
+  if (snapshot.yearMonth !== currentYearMonth) {
+    throw new Error(
+      `version.json yearMonth must match the current KST month. Expected ${currentYearMonth}, received ${snapshot.yearMonth}.`
+    )
+  }
+
+  const packageJson = readJsonFile(PACKAGE_JSON_PATH)
+
+  if (packageJson.version !== snapshot.packageVersion) {
+    throw new Error(
+      `package.json version must match the derived semver. Expected ${snapshot.packageVersion}, received ${packageJson.version}.`
+    )
+  }
+
+  if (fs.existsSync(PACKAGE_LOCK_PATH)) {
+    const packageLock = readJsonFile(PACKAGE_LOCK_PATH)
+    const packageLockVersion = packageLock.packages?.['']?.version
+
+    if (
+      packageLock.version !== snapshot.packageVersion ||
+      packageLockVersion !== snapshot.packageVersion
+    ) {
+      throw new Error(
+        `package-lock.json version must match the derived semver. Expected ${snapshot.packageVersion}, received ${packageLock.version} / ${packageLockVersion}.`
+      )
+    }
+  }
+
+  return snapshot
+}
+
+function printUsage() {
+  console.error(
+    [
+      'Usage:',
+      '  node scripts/version.js sync',
+      '  node scripts/version.js check',
+      '  node scripts/version.js json',
+      '  node scripts/version.js xcconfig',
+    ].join('\n')
+  )
+}
+
+if (require.main === module) {
+  const command = process.argv[2]
+
+  try {
+    if (command === 'sync') {
+      const snapshot = syncVersionYearMonth()
+      console.log(
+        `Updated version files to ${snapshot.marketingVersion} (${snapshot.versionCode}), package ${snapshot.packageVersion}`
+      )
+    } else if (command === 'check') {
+      const snapshot = checkVersionConfig()
+      console.log(
+        `Version config is current: ${snapshot.marketingVersion} (${snapshot.versionCode}), package ${snapshot.packageVersion}`
+      )
+    } else if (command === 'json') {
+      const snapshot = getVersionSnapshot(readVersionConfig())
+      console.log(JSON.stringify(snapshot, null, 2))
+    } else if (command === 'xcconfig') {
+      const snapshot = getVersionSnapshot(readVersionConfig())
+      console.log(`OFFNAL_MARKETING_VERSION = ${snapshot.marketingVersion}`)
+      console.log(`OFFNAL_VERSION_CODE = ${snapshot.versionCode}`)
+    } else {
+      printUsage()
+      process.exitCode = 1
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  checkVersionConfig,
+  formatMarketingVersion,
+  formatVersionCode,
+  getKstYearMonth,
+  getVersionSnapshot,
+  formatPackageVersion,
+  readVersionConfig,
+  syncVersionYearMonth,
+  validateVersionConfig,
+  VERSION_FILE_PATH,
+}

--- a/src/infrastructure/remote/axios/createApiAxiosClient.ts
+++ b/src/infrastructure/remote/axios/createApiAxiosClient.ts
@@ -31,24 +31,27 @@ apiAxiosClient.interceptors.request.use(config => {
   return config
 })
 
-openApiAxiosClient.interceptors.request.use(config => {
+apiAxiosClient.interceptors.response.use(response => {
   if (!__DEV__) {
-    return config
+    return response
   }
 
-  console.log('🧑🏻‍💻 Request Interceptor | Request URL:', config.url)
+  console.log('🧑🏻‍💻 Response Interceptor | Response URL:', response.config.url)
   console.log(
-    '🧑🏻‍💻 Request Interceptor | Authorization: ',
-    config.headers.Authorization
+    '🧑🏻‍💻 Response Interceptor | Authorization: ',
+    response.config.headers.Authorization
   )
   console.log(
-    '🧑🏻‍💻 Request Interceptor | Content-Type: ',
-    config.headers['Content-Type']
+    '🧑🏻‍💻 Response Interceptor | Content-Type: ',
+    response.config.headers['Content-Type']
   )
-  console.log('🧑🏻‍💻 Request Interceptor | Request params:', config.params)
-  console.log('🧑🏻‍💻 Request Interceptor | Request body:', config.data)
+  console.log(
+    '🧑🏻‍💻 Response Interceptor | Response params:',
+    response.config.params
+  )
+  console.log('🧑🏻‍💻 Response Interceptor | Response body:', response.data)
 
-  return config
+  return response
 })
 
 // Request Interceptor With AccessToken

--- a/src/infrastructure/remote/axios/createOpenApiAxiosClient.ts
+++ b/src/infrastructure/remote/axios/createOpenApiAxiosClient.ts
@@ -5,3 +5,23 @@ export const openApiAxiosClient = axios.create({
   baseURL: OPEN_API_URL,
   timeout: 10000,
 })
+
+openApiAxiosClient.interceptors.request.use(config => {
+  if (!__DEV__) {
+    return config
+  }
+
+  console.log('🧑🏻‍💻 Request Interceptor | Request URL:', config.url)
+  console.log(
+    '🧑🏻‍💻 Request Interceptor | Authorization: ',
+    config.headers.Authorization
+  )
+  console.log(
+    '🧑🏻‍💻 Request Interceptor | Content-Type: ',
+    config.headers['Content-Type']
+  )
+  console.log('🧑🏻‍💻 Request Interceptor | Request params:', config.params)
+  console.log('🧑🏻‍💻 Request Interceptor | Request body:', config.data)
+
+  return config
+})

--- a/src/presentation/info/screen/InformationScreen.tsx
+++ b/src/presentation/info/screen/InformationScreen.tsx
@@ -16,6 +16,7 @@ import { useUserStore } from '../../../store/useUserStore'
 import { authService } from '../../../infrastructure/di/Dependencies'
 import { useResetAllStore } from '../../../shared/hooks/useResetAllStore'
 import ConfirmDialog from '../../../shared/components/dialog/ConfirmDialog'
+import { appVersionLabel } from '../../../shared/config/appVersion'
 
 const InformationScreen = () => {
   const navigation = useNavigation<rootNavigation>()
@@ -43,7 +44,7 @@ const InformationScreen = () => {
       {
         id: 'version',
         title: '현재 버전',
-        caption: '1.0.0',
+        caption: appVersionLabel,
         onPress: () => {
           /* TODO("Not yet Implemeted") */
         },

--- a/src/presentation/login/components/KakaoLoginBtn.tsx
+++ b/src/presentation/login/components/KakaoLoginBtn.tsx
@@ -15,7 +15,7 @@ const KaKaoLoginBtn = ({
     <TouchableOpacity
       onPress={onPress}
       disabled={disabled || loading}
-      className="mb-number-8 h-12 w-full flex-row items-center justify-center rounded-radius-xs bg-kakao-bg px-[14px]"
+      className="mb-number-8 h-12 w-[300px] flex-row items-center justify-center rounded-radius-xs bg-kakao-bg px-[14px]"
     >
       <KakaoLogo />
       <View className="px-[86px]">

--- a/src/shared/config/appVersion.ts
+++ b/src/shared/config/appVersion.ts
@@ -1,45 +1,12 @@
 import versionConfig from '../../../version.json'
+import { getVersionSnapshot } from './versionUtils'
 
 type VersionConfig = {
   buildNumber: number
   yearMonth: string
 }
-
-const versionMonthPattern = /^\d{4}\.\d{2}$/
-
 const normalizedVersionConfig = versionConfig as VersionConfig
-
-if (!versionMonthPattern.test(normalizedVersionConfig.yearMonth)) {
-  throw new Error(
-    `[appVersion] Invalid yearMonth "${normalizedVersionConfig.yearMonth}".`
-  )
-}
-
-if (
-  !Number.isInteger(normalizedVersionConfig.buildNumber) ||
-  normalizedVersionConfig.buildNumber < 1 ||
-  normalizedVersionConfig.buildNumber > 999
-) {
-  throw new Error(
-    `[appVersion] Invalid buildNumber "${normalizedVersionConfig.buildNumber}".`
-  )
-}
-
-const [yearPart, monthPart] = normalizedVersionConfig.yearMonth.split('.')
-const year = Number(yearPart)
-const month = Number(monthPart)
-
-if (!Number.isInteger(year) || !Number.isInteger(month)) {
-  throw new Error(
-    `[appVersion] Invalid yearMonth "${normalizedVersionConfig.yearMonth}".`
-  )
-}
-
-const marketingVersion = `${normalizedVersionConfig.yearMonth}.${String(
-  normalizedVersionConfig.buildNumber
-).padStart(3, '0')}`
-const versionCode =
-  year * 100000 + month * 1000 + normalizedVersionConfig.buildNumber
+const snapshot = getVersionSnapshot(normalizedVersionConfig)
 
 export type AppVersion = {
   buildNumber: number
@@ -49,12 +16,12 @@ export type AppVersion = {
 }
 
 export const appVersion: AppVersion = {
-  buildNumber: normalizedVersionConfig.buildNumber,
-  marketingVersion,
-  versionCode,
-  yearMonth: normalizedVersionConfig.yearMonth,
+  buildNumber: snapshot.buildNumber,
+  marketingVersion: snapshot.marketingVersion,
+  versionCode: snapshot.versionCode,
+  yearMonth: snapshot.yearMonth,
 }
 
-export const appVersionLabel = marketingVersion
+export const appVersionLabel = snapshot.marketingVersion
 
 export default appVersion

--- a/src/shared/config/appVersion.ts
+++ b/src/shared/config/appVersion.ts
@@ -1,0 +1,60 @@
+import versionConfig from '../../../version.json'
+
+type VersionConfig = {
+  buildNumber: number
+  yearMonth: string
+}
+
+const versionMonthPattern = /^\d{4}\.\d{2}$/
+
+const normalizedVersionConfig = versionConfig as VersionConfig
+
+if (!versionMonthPattern.test(normalizedVersionConfig.yearMonth)) {
+  throw new Error(
+    `[appVersion] Invalid yearMonth "${normalizedVersionConfig.yearMonth}".`
+  )
+}
+
+if (
+  !Number.isInteger(normalizedVersionConfig.buildNumber) ||
+  normalizedVersionConfig.buildNumber < 1 ||
+  normalizedVersionConfig.buildNumber > 999
+) {
+  throw new Error(
+    `[appVersion] Invalid buildNumber "${normalizedVersionConfig.buildNumber}".`
+  )
+}
+
+const [yearPart, monthPart] = normalizedVersionConfig.yearMonth.split('.')
+const year = Number(yearPart)
+const month = Number(monthPart)
+
+if (!Number.isInteger(year) || !Number.isInteger(month)) {
+  throw new Error(
+    `[appVersion] Invalid yearMonth "${normalizedVersionConfig.yearMonth}".`
+  )
+}
+
+const marketingVersion = `${normalizedVersionConfig.yearMonth}.${String(
+  normalizedVersionConfig.buildNumber
+).padStart(3, '0')}`
+const versionCode =
+  year * 100000 + month * 1000 + normalizedVersionConfig.buildNumber
+
+export type AppVersion = {
+  buildNumber: number
+  marketingVersion: string
+  versionCode: number
+  yearMonth: string
+}
+
+export const appVersion: AppVersion = {
+  buildNumber: normalizedVersionConfig.buildNumber,
+  marketingVersion,
+  versionCode,
+  yearMonth: normalizedVersionConfig.yearMonth,
+}
+
+export const appVersionLabel = marketingVersion
+
+export default appVersion

--- a/src/shared/config/versionUtils.js
+++ b/src/shared/config/versionUtils.js
@@ -1,0 +1,112 @@
+/**
+ * @typedef {Object} VersionConfig
+ * @property {string} yearMonth
+ * @property {number} buildNumber
+ *
+ * @typedef {VersionConfig & {
+ *   marketingVersion: string
+ *   packageVersion: string
+ *   versionCode: number
+ * }} VersionSnapshot
+ */
+
+const VERSION_MONTH_PATTERN = /^\d{4}\.\d{2}$/
+
+/**
+ * @param {VersionConfig} versionConfig
+ * @returns {VersionConfig}
+ */
+function validateVersionConfig(versionConfig) {
+  const yearMonth = String(versionConfig.yearMonth ?? '')
+  const buildNumber = Number(versionConfig.buildNumber)
+
+  if (!VERSION_MONTH_PATTERN.test(yearMonth)) {
+    throw new Error(
+      `Invalid yearMonth "${yearMonth}". Expected the format YYYY.MM.`
+    )
+  }
+
+  if (!Number.isInteger(buildNumber) || buildNumber < 1 || buildNumber > 999) {
+    throw new Error(
+      `Invalid buildNumber "${versionConfig.buildNumber}". Expected an integer between 1 and 999.`
+    )
+  }
+
+  return {
+    yearMonth,
+    buildNumber,
+  }
+}
+
+/**
+ * @param {string} yearMonth
+ * @param {number} buildNumber
+ * @returns {string}
+ */
+function formatMarketingVersion(yearMonth, buildNumber) {
+  return `${yearMonth}.${String(buildNumber).padStart(3, '0')}`
+}
+
+/**
+ * @param {string} yearMonth
+ * @param {number} buildNumber
+ * @returns {string}
+ */
+function formatPackageVersion(yearMonth, buildNumber) {
+  const [yearPart, monthPart] = yearMonth.split('.')
+  const year = Number(yearPart)
+  const month = Number(monthPart)
+
+  if (!Number.isInteger(year) || !Number.isInteger(month)) {
+    throw new Error(`Invalid yearMonth "${yearMonth}"`)
+  }
+
+  return `${year}.${month}.${buildNumber}`
+}
+
+/**
+ * @param {string} yearMonth
+ * @param {number} buildNumber
+ * @returns {number}
+ */
+function formatVersionCode(yearMonth, buildNumber) {
+  const [yearPart, monthPart] = yearMonth.split('.')
+  const year = Number(yearPart)
+  const month = Number(monthPart)
+
+  if (!Number.isInteger(year) || !Number.isInteger(month)) {
+    throw new Error(`Invalid yearMonth "${yearMonth}"`)
+  }
+
+  return year * 100000 + month * 1000 + buildNumber
+}
+
+/**
+ * @param {VersionConfig} versionConfig
+ * @returns {VersionSnapshot}
+ */
+function getVersionSnapshot(versionConfig) {
+  const validated = validateVersionConfig(versionConfig)
+
+  return {
+    ...validated,
+    marketingVersion: formatMarketingVersion(
+      validated.yearMonth,
+      validated.buildNumber
+    ),
+    packageVersion: formatPackageVersion(
+      validated.yearMonth,
+      validated.buildNumber
+    ),
+    versionCode: formatVersionCode(validated.yearMonth, validated.buildNumber),
+  }
+}
+
+module.exports = {
+  VERSION_MONTH_PATTERN,
+  formatMarketingVersion,
+  formatPackageVersion,
+  formatVersionCode,
+  getVersionSnapshot,
+  validateVersionConfig,
+}

--- a/version.json
+++ b/version.json
@@ -1,0 +1,4 @@
+{
+  "yearMonth": "2026.04",
+  "buildNumber": 1
+}


### PR DESCRIPTION
## 개요
앱 릴리즈 버전 관리 방식을 `major.minor.patch` 중심에서 `year.month.build` 중심으로 정리했습니다.  
버전의 단일 원본은 `version.json`으로 두고, 앱 표시용 버전과 npm 패키지 버전을 자동 동기화하도록 구성했습니다.

## 변경 내용
- `version.json`을 버전의 단일 source of truth로 추가했습니다.
- `yearMonth`는 KST 기준 현재 월로 자동 동기화되도록 했습니다.
- `buildNumber`는 개발자가 수동으로 관리하도록 유지했습니다.
- 앱 표시용 버전은 `2026.04.001` 형태로 zero-pad 되도록 변경했습니다.
- `package.json.version`은 `2026.4.1` 형태로 자동 sync 되도록 했습니다.
- `package-lock.json`의 루트 버전도 `package.json`과 함께 동기화되도록 했습니다.
- Android 릴리즈 버전은 `version.json` 기준으로 `versionName`, `versionCode`를 계산하도록 변경했습니다.
- iOS 릴리즈 버전은 `version.json` 기준으로 `MARKETING_VERSION`, `CURRENT_PROJECT_VERSION`를 주입하도록 변경했습니다.
- 정보 화면의 버전 표기는 하드코딩을 제거하고 공통 버전 소스를 사용하도록 변경했습니다.
- CI에서 버전 정합성만 검증하도록 `version:check` 단계를 추가했습니다.
- 배포 이슈 템플릿의 버전 예시를 새 버전 포맷에 맞게 수정했습니다.
- `react-native-sqlite-storage` 테스트용 mock을 추가해 Jest 초기 로딩 실패를 방지했습니다.

## 버전 정책
- `version.json`
  - `yearMonth`: 자동 갱신 대상
  - `buildNumber`: 수동 관리 대상
- 앱 표시 버전
  - `YYYY.MM.###` 형식
  - 예: `2026.04.001`
- npm 패키지 버전
  - `YYYY.M.B` 형식
  - 예: `2026.4.1`

## 동작 방식
- 새 달로 넘어가면 `npm run version:sync`를 실행해 `yearMonth`, `package.json`, `package-lock.json`을 함께 갱신합니다.
- 같은 달 내 빌드에서는 `version.json.buildNumber`만 올리면 됩니다.
- CI는 버전을 수정하지 않고, 현재 파일들의 정합성만 검사합니다.

## 검증
- `node scripts/version.js check`
- `npm test -- --runInBand --no-watchman __tests__/appVersion.test.ts`
- `npm run lint`
- `cd android && ./gradlew assembleProductRelease`

## 참고
- `version.json`만 수정하는 것으로 끝나는 구조가 아니라, 최종적으로는 `npm run version:sync`를 통해 `package.json`과 `package-lock.json`까지 맞춰야 합니다.
- Play Store 배포본과 Kakao 로그인 검증은 Play App Signing 기준으로 확인해야 합니다.

