### PR TITLE
[PR]: [OFFNAL-153] [KanuKim97]: 오늘의 루틴 전부 체크 시, 바텀시트 표출

### DIFF
--- a/src/assets/icons/ic_routine_complete_character.svg
+++ b/src/assets/icons/ic_routine_complete_character.svg
@@ -1,0 +1,114 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 69.8105 67.6848" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 2147224524">
+<g id="Ellipse 1343" filter="url(#filter0_ii_0_90)">
+<ellipse cx="35.6042" cy="33.8424" rx="34.2063" ry="33.8424" fill="#B9EDF3"/>
+</g>
+<g id="Group 183">
+<path id="Vector 113" d="M54.4083 37.4146C52.0259 38.2455 52.1989 41.5852 52.5832 43.1512C52.6226 43.2847 53.2221 43.4268 55.3054 42.9272C57.3886 42.4276 57.7946 40.5145 57.7372 39.6204C57.6202 38.5389 56.7906 36.5837 54.4083 37.4146Z" fill="#3B3A39"/>
+<path id="Vector 114" d="M28.6139 44.0213C30.1293 46.6529 33.0362 45.709 34.3002 44.908C34.4058 44.8319 34.336 44.0919 33.2122 41.7404C32.0885 39.3889 30.2583 39.3327 29.4838 39.5985C28.5624 39.9763 27.0985 41.3897 28.6139 44.0213Z" fill="#3B3A39"/>
+<g id="Ellipse 55" filter="url(#filter1_g_0_90)">
+<ellipse cx="1.1502" cy="1.22589" rx="1.1502" ry="1.22589" transform="matrix(0.892594 0.450861 -0.323946 0.946075 48.8278 32.4896)" fill="#696867"/>
+</g>
+<g id="Ellipse 56" filter="url(#filter2_g_0_90)">
+<ellipse cx="1.1502" cy="1.22589" rx="1.1502" ry="1.22589" transform="matrix(0.892594 0.450861 -0.323946 0.946075 33.3624 33.457)" fill="#696867"/>
+</g>
+<g id="Ellipse 57" filter="url(#filter3_i_0_90)">
+<ellipse cx="5.69049" cy="6.06492" rx="5.69049" ry="6.06492" transform="matrix(0.685581 0.727997 -0.626896 0.779103 49.5375 40.6467)" fill="#FFF6D9"/>
+</g>
+<g id="Ellipse 58" filter="url(#filter4_i_0_90)">
+<ellipse cx="5.69049" cy="6.06492" rx="5.69049" ry="6.06492" transform="matrix(0.892594 0.450861 -0.323946 0.946075 36.4788 41.2952)" fill="#FFF6D9"/>
+</g>
+<path id="Vector 115" d="M46.4401 45.7281L45.546 47.5757C45.2303 48.2282 44.3704 48.2246 43.9448 47.569L42.8446 45.8742C42.409 45.2033 42.7358 44.3287 43.4423 44.2745L45.4366 44.1217C46.204 44.0629 46.7911 45.0027 46.4401 45.7281Z" fill="#696867"/>
+<ellipse id="Ellipse 59" cx="0.750954" cy="0.800367" rx="0.750954" ry="0.800367" transform="matrix(0.892594 0.450861 -0.323946 0.946075 29.5226 40.3313)" fill="white"/>
+<ellipse id="Ellipse 60" cx="0.709267" cy="0.755936" rx="0.709267" ry="0.755936" transform="matrix(0.892594 0.450861 -0.323946 0.946075 54.5884 38.4511)" fill="white"/>
+</g>
+<g id="Group 211">
+<g id="Group 210">
+<path id="Vector 157" d="M65.2563 20.0266C52.7039 28.8133 28.1114 24.0636 14.0197 19.4134C11.4102 18.5523 8.45743 16.3058 9.5793 13.7972C10.5071 11.7225 13.6179 11.6935 15.3822 12.1086C37.8163 18.3403 52.4492 18.183 60.0934 14.5399C62.2484 13.5129 64.9192 12.0704 66.5899 13.7754C66.9024 14.0943 67.1412 14.4566 67.32 14.8382C68.2044 16.7255 66.9638 18.8313 65.2563 20.0266Z" fill="#EDC0FF"/>
+<path id="Vector 158" d="M23.0513 2.6347C44.2537 -5.48536 58.2396 7.29652 64.1042 13.0107C57.7883 21.1309 29.3671 23.8379 12.6756 12.1087C9.83845 10.115 6.74907 14.5263 6.01429 15.8534C5.98164 16.0091 5.9529 16.1158 5.9088 16.1688C5.80192 16.2973 5.84729 16.155 6.01429 15.8534C6.31558 14.4162 6.94999 8.80116 23.0513 2.6347Z" fill="#F7E3FF"/>
+<g id="Mask group">
+<mask id="mask0_0_90" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="5" y="0" width="60" height="21">
+<path id="Vector 159" d="M23.0512 2.63463C44.2536 -5.48542 58.2395 7.29645 64.104 13.0106C57.7882 21.1308 29.367 23.8378 12.6755 12.1087C9.83833 10.115 6.74894 14.5263 6.01417 15.8533C5.98151 16.0091 5.95277 16.1158 5.90868 16.1688C5.80179 16.2972 5.84716 16.1549 6.01417 15.8533C6.31546 14.4161 6.94987 8.80109 23.0512 2.63463Z" fill="#F7E3FF"/>
+</mask>
+<g mask="url(#mask0_0_90)">
+<ellipse id="Ellipse 1354" cx="48.7651" cy="17.523" rx="3.15784" ry="3.15784" fill="#F4F5F6"/>
+<ellipse id="Ellipse 1359" cx="25.3069" cy="14.8163" rx="3.15784" ry="3.15784" fill="#F4F5F6"/>
+<ellipse id="Ellipse 1360" cx="15.3822" cy="8.50059" rx="3.15784" ry="3.15784" fill="#F4F5F6"/>
+<ellipse id="Ellipse 1357" cx="43.3517" cy="2.18491" rx="3.15784" ry="3.15784" fill="#F4F5F6"/>
+<ellipse id="Ellipse 1358" cx="37.9382" cy="11.2073" rx="3.15784" ry="3.15784" fill="#F4F5F6"/>
+<ellipse id="Ellipse 1355" cx="56.8853" cy="11.2073" rx="3.15784" ry="3.15784" fill="#F4F5F6"/>
+<ellipse id="Ellipse 1356" cx="28.0136" cy="3.98939" rx="3.15784" ry="3.15784" fill="#F4F5F6"/>
+</g>
+</g>
+</g>
+<g id="Ellipse 1361" filter="url(#filter5_g_0_90)">
+<ellipse cx="5.90896" cy="17.1513" rx="3.60896" ry="3.60896" fill="#FFFABF"/>
+</g>
+</g>
+</g>
+<defs>
+<filter id="filter0_ii_0_90" x="-2.60214" y="-3" width="79.3126" height="74.6848" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="9" dy="4"/>
+<feGaussianBlur stdDeviation="3.45"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_0_90"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-4" dy="-3"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="effect1_innerShadow_0_90" result="effect2_innerShadow_0_90"/>
+</filter>
+<filter id="filter1_g_0_90" x="46.9562" y="31.4972" width="5.00218" height="5.34152" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.99900001287460327 0.99900001287460327" numOctaves="3" seed="9778" />
+<feDisplacementMap in="shape" scale="2.7999999523162842" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_0_90">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+<filter id="filter2_g_0_90" x="31.4908" y="32.4646" width="5.00218" height="5.34152" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.99900001287460327 0.99900001287460327" numOctaves="3" seed="9778" />
+<feDisplacementMap in="shape" scale="2.7999999523162842" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_0_90">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+<filter id="filter3_i_0_90" x="44.1891" y="43.2305" width="12.8951" height="14.5682" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_0_90"/>
+</filter>
+<filter id="filter4_i_0_90" x="34.1459" y="43.3118" width="12.895" height="14.5738" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_0_90"/>
+</filter>
+<filter id="filter5_g_0_90" x="0" y="11.2423" width="11.8179" height="11.8179" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feTurbulence type="fractalNoise" baseFrequency="0.99900001287460327 0.99900001287460327" numOctaves="3" seed="8432" />
+<feDisplacementMap in="shape" scale="4.5999999046325684" xChannelSelector="R" yChannelSelector="G" result="displacedImage" width="100%" height="100%" />
+<feMerge result="effect1_texture_0_90">
+<feMergeNode in="displacedImage"/>
+</feMerge>
+</filter>
+</defs>
+</svg>

--- a/src/presentation/dailyRoutine/component/DailyRoutineCompletionBottomSheet.tsx
+++ b/src/presentation/dailyRoutine/component/DailyRoutineCompletionBottomSheet.tsx
@@ -1,0 +1,144 @@
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
+  BottomSheetView,
+} from '@gorhom/bottom-sheet'
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from 'react'
+import { View } from 'react-native'
+import RoutineCompleteCharacter from '../../../assets/icons/ic_routine_complete_character.svg'
+import EmphasizedButton from '../../../shared/components/button/Button'
+import GlobalText from '../../../shared/components/text/GlobalText'
+import { GoalState, GoalStatusIcon } from '../../main/components/GoalStatusCard'
+
+export interface DailyRoutineCompletionBottomSheetMethods {
+  open: () => void
+  close: () => void
+}
+
+interface DailyRoutineCompletionBottomSheetProps {
+  onChange?: (index: number) => void
+}
+
+const WEEK_LABELS = ['월', '화', '수', '목', '금', '토', '일']
+
+const PLACEHOLDER_GOAL_STATES: GoalState[] = [
+  'done',
+  'missed',
+  'streak',
+  'streak',
+  'streak',
+  'missed',
+  'done',
+]
+
+const BottomSheetHandle = () => null
+
+const DailyRoutineCompletionBottomSheet = forwardRef<
+  DailyRoutineCompletionBottomSheetMethods,
+  DailyRoutineCompletionBottomSheetProps
+>(({ onChange }, ref) => {
+  const bottomSheetRef = useRef<BottomSheet>(null)
+  const snapPoints = useMemo(() => ['44%'], [])
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        opacity={0.75}
+        pressBehavior="close"
+      />
+    ),
+    []
+  )
+
+  useImperativeHandle(ref, () => ({
+    open: () => {
+      bottomSheetRef.current?.expand()
+    },
+    close: () => {
+      bottomSheetRef.current?.close()
+    },
+  }))
+
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      index={-1}
+      snapPoints={snapPoints}
+      backdropComponent={renderBackdrop}
+      onChange={onChange}
+      enablePanDownToClose={true}
+      enableContentPanningGesture={false}
+      handleComponent={BottomSheetHandle}
+      backgroundStyle={{
+        backgroundColor: '#ffffff',
+        borderTopLeftRadius: 24,
+        borderTopRightRadius: 24,
+      }}
+    >
+      <BottomSheetView className="items-center px-[20px] pb-[16px] pt-[36px]">
+        <View className="w-full items-center gap-[16px]">
+          <View className="w-full gap-[12px] pb-[16px]">
+            <View className="w-full flex-row items-center justify-center gap-[8px] overflow-hidden px-[10px] py-[20px]">
+              <RoutineCompleteCharacter width={69} height={68} />
+
+              <View className="rounded-radius-xl bg-surface-primary-light px-[12px] py-[12px]">
+                <GlobalText className="font-pretMedium text-body-xs text-text-disabled-on">
+                  기세가 엄청나요!
+                </GlobalText>
+              </View>
+            </View>
+
+            <View className="border-t border-dashed border-border-gray-light" />
+
+            <View className="flex-row items-center justify-center">
+              <GlobalText className="font-pretSemiBold text-heading-xxs text-text-primary">
+                23
+              </GlobalText>
+              <GlobalText className="font-pretMedium text-body-s text-text-subtle">
+                일째 꾸준하게 생활패턴을 유지하셨어요!
+              </GlobalText>
+            </View>
+          </View>
+
+          <View className="w-full gap-[8px] rounded-radius-l px-[24px] py-[12px]">
+            <View className="flex-row justify-between">
+              {WEEK_LABELS.map(label => (
+                <View key={label} className="w-[32px] items-center">
+                  <GlobalText className="font-pretSemiBold text-heading-xxxxs text-text-disabled-on">
+                    {label}
+                  </GlobalText>
+                </View>
+              ))}
+            </View>
+
+            <View className="h-[43px] flex-row items-end justify-between">
+              {PLACEHOLDER_GOAL_STATES.map((state, index) => (
+                <GoalStatusIcon key={`${state}-${index}`} state={state} />
+              ))}
+            </View>
+          </View>
+
+          <EmphasizedButton
+            onPress={() => bottomSheetRef.current?.close()}
+            content={
+              <GlobalText className="font-pretMedium text-body-m text-text-bolder-inverse">
+                이전으로
+              </GlobalText>
+            }
+          />
+        </View>
+      </BottomSheetView>
+    </BottomSheet>
+  )
+})
+
+export default DailyRoutineCompletionBottomSheet

--- a/src/presentation/dailyRoutine/screen/DailyRoutineScreen.tsx
+++ b/src/presentation/dailyRoutine/screen/DailyRoutineScreen.tsx
@@ -1,5 +1,12 @@
 import '../../../../global.css'
-import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native'
 import type { NativeStackHeaderProps } from '@react-navigation/native-stack'
 import { ScrollView, View } from 'react-native'
@@ -20,6 +27,9 @@ import {
   RoutineDay,
 } from '../../../shared/components/routine/routineContent'
 import { useRoutineStore } from '../../../store/useRoutineStore'
+import DailyRoutineCompletionBottomSheet, {
+  DailyRoutineCompletionBottomSheetMethods,
+} from '../component/DailyRoutineCompletionBottomSheet'
 
 type FloatingRoutineActionButtonProps = {
   onPress: () => void
@@ -67,6 +77,12 @@ const DailyRoutineScreen = () => {
     route.params?.day ?? 'today'
   )
   const currentTimeMillis = useCurrentTimeTick()
+  const completionBottomSheetRef =
+    useRef<DailyRoutineCompletionBottomSheetMethods>(null)
+  const hasShownCompletionSheetRef = useRef(false)
+  const shouldShowCompletionSheetAfterToggleRef = useRef(false)
+  const [isCompletionBottomSheetOpen, setIsCompletionBottomSheetOpen] =
+    useState(false)
   const completionByDay = useRoutineStore(state => state.completionByDay)
   const toggleRoutineCompletion = useRoutineStore(
     state => state.toggleRoutineCompletion
@@ -90,6 +106,7 @@ const DailyRoutineScreen = () => {
 
   const handleToggleCompletion = useCallback(
     (itemId: string) => {
+      shouldShowCompletionSheetAfterToggleRef.current = routineDay === 'today'
       toggleRoutineCompletion(routineDay, itemId)
     },
     [routineDay, toggleRoutineCompletion]
@@ -102,9 +119,47 @@ const DailyRoutineScreen = () => {
     []
   )
 
+  const handleCompletionBottomSheetChange = useCallback((index: number) => {
+    setIsCompletionBottomSheetOpen(index >= 0)
+  }, [])
+
   useLayoutEffect(() => {
     navigation.setOptions({ header: DailyRoutineHeader })
   }, [navigation])
+
+  const isTodayRoutineCompleted = useMemo(() => {
+    if (routineDay !== 'today') {
+      return false
+    }
+
+    const routineItems = dailySections.flatMap(section => section.items)
+
+    return (
+      routineItems.length > 0 &&
+      routineItems.every(item => item.state === 'done')
+    )
+  }, [dailySections, routineDay])
+
+  useEffect(() => {
+    if (!isTodayRoutineCompleted) {
+      hasShownCompletionSheetRef.current = false
+      shouldShowCompletionSheetAfterToggleRef.current = false
+      setIsCompletionBottomSheetOpen(false)
+      return
+    }
+
+    if (
+      hasShownCompletionSheetRef.current ||
+      !shouldShowCompletionSheetAfterToggleRef.current
+    ) {
+      return
+    }
+
+    hasShownCompletionSheetRef.current = true
+    shouldShowCompletionSheetAfterToggleRef.current = false
+    setIsCompletionBottomSheetOpen(true)
+    completionBottomSheetRef.current?.open()
+  }, [isTodayRoutineCompleted])
 
   return (
     <View className="flex-1 bg-background-white">
@@ -124,13 +179,20 @@ const DailyRoutineScreen = () => {
         ))}
       </ScrollView>
 
-      <FloatingRoutineActionButton
-        onPress={handleToggleRoutineDay}
-        content={
-          <GlobalText className="font-pretMedium text-body-m text-text-bolder-inverse">
-            {isTomorrow ? '오늘 루틴 확인하기' : '내일 루틴 확인하기'}
-          </GlobalText>
-        }
+      {!isCompletionBottomSheetOpen && (
+        <FloatingRoutineActionButton
+          onPress={handleToggleRoutineDay}
+          content={
+            <GlobalText className="font-pretMedium text-body-m text-text-bolder-inverse">
+              {isTomorrow ? '오늘 루틴 확인하기' : '내일 루틴 확인하기'}
+            </GlobalText>
+          }
+        />
+      )}
+
+      <DailyRoutineCompletionBottomSheet
+        ref={completionBottomSheetRef}
+        onChange={handleCompletionBottomSheetChange}
       />
     </View>
   )

--- a/src/presentation/main/components/GoalStatusCard.tsx
+++ b/src/presentation/main/components/GoalStatusCard.tsx
@@ -5,7 +5,7 @@ import GlobalText from '../../../shared/components/text/GlobalText'
 import CheckIcon from '../../../assets/icons/ic_checked.svg'
 import CheckStreakIcon from '../../../assets/icons/ic_goal_streak.svg'
 
-type GoalState = 'missed' | 'streak' | 'done'
+export type GoalState = 'missed' | 'streak' | 'done'
 
 interface GoalStatusCardProps {
   states: GoalState[]


### PR DESCRIPTION
### Summary
오늘의 루틴 화면을 새로 구성하고, 오늘의 루틴을 모두 체크했을 때 완료 바텀시트가 노출되도록 개선했습니다.
동시에 홈 화면을 근무 형태 기반의 루틴/건강 카드 구조로 재정리하고, 루틴 콘텐츠 생성 로직을 공통 유틸로 분리했습니다.

### Key Changes
 - DailyRoutineScreen에 today / tomorrow 전환 기능을 추가하고, 루틴 완료 상태를 일자별로 관리하도록 구성했습니다.
 - 오늘 루틴의 모든 항목이 완료되면 DailyRoutineCompletionBottomSheet가 한 번만 노출되도록 처리했습니다.
 - 과거 시간대 루틴은 비활성화하고, 현재 진행 중인 루틴은 강조 표시되도록 시간 기반 상태 계산을 적용했습니다.
 - routineContent.ts에서 메인 화면용 루틴 카드와 상세 루틴 화면용 섹션 데이터를 생성하는 공통 로직을 분리했습니다.
 - 루틴 카드, 루틴 섹션, 일러스트 매핑, 시간 윈도우 판별 로직을 공통 컴포넌트/유틸로 정리했습니다.
 - 홈 화면을 TopBanner + HomeCarePanel 구조로 재구성하고, 다음 섹션들을 배치했습니다.
```
근무 전 루틴
근무 중 루틴
퇴근 후 루틴
오늘 나의 건강 관리 카드
금주 나의 목표 달성 확인
추천 건강 컨텐츠
```
- 근무 타입 코드를 workType 상수에서 중앙 관리하도록 정리해, 레거시 라벨과 신규 코드 모두 처리할 수 있게 했습니다.
- 루트 네비게이션에 DailyRoutine 화면을 추가해 탭 바 흐름과 분리했습니다.
- 루틴/완료 상태 표현에 필요한 SVG 아이콘과 iOS 리소스 등록을 추가했습니다.

### 테스트
__tests__/shared/components/routine/routineContent.test.ts
__tests__/shared/components/routine/routineIllustrationMap.test.ts
__tests__/shared/constants/workType.test.ts


### 스크린샷 / 영상

https://github.com/user-attachments/assets/cb45aca9-7729-4651-acf8-129829a2f2d1

### 부록
- ios/Offnal.xcodeproj/project.pbxproj는 새 아이콘/리소스 등록을 반영한 변경이 포함되어 있습니다.
-package-lock.json도 함께 갱신되었습니다.
- 로컬에서 전체 lint / test 실행 여부는 별도 확인이 필요합니다.


### 체크리스트 (Checklist)

PR을 올리기 전 아래 항목들을 확인해주세요.

- [ ] `main` 브랜치에 직접 푸시하지 않았나요?
- [ ] 모든 변경 사항에 대한 테스트를 수행했나요?
- [ ] 코드 주석이 필요한 부분에 적절히 추가되었나요?
- [ ] 변경으로 인한 새로운 버그가 발생할 가능성은 없나요?
- [ ] 의존성 변경이 필요한 경우 `package.json` 또는 `build.gradle` 등을 업데이트했나요?

