### PR TITLE
PR: [ios-script][KanuKim97]: ios 빌드 스크립트 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "android:dev": "ENVFILE=env/.env.development react-native run-android --mode=developdebug",
     "android:prod": "ENVFILE=env/.env.production react-native run-android --mode=productrelease",
-    "ios:dev": "ENVFILE=env/.env.development react-native run-ios --scheme Development",
-    "ios:prod": "ENVFILE=env/.env.production react-native run-ios --scheme Production",
+    "ios:dev": "bash scripts/ios-device-run.sh Development Debug env/.env.development",
+    "ios:prod": "bash scripts/ios-device-run.sh Production Release env/.env.production",
     "lint": "eslint .",
     "version:check": "node scripts/version.js check",
     "version:sync": "node scripts/version.js sync",

--- a/scripts/ios-device-run.sh
+++ b/scripts/ios-device-run.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE_PATH="${ROOT_DIR}/ios/Offnal.xcworkspace"
+SCHEME="${1:-Development}"
+CONFIGURATION="${2:-Debug}"
+ENVFILE_PATH="${3:-env/.env.development}"
+DEVICE_ID="${DEVICE_ID:-${4:-}}"
+DEVICE_NAME="${DEVICE_NAME:-iPhone}"
+BUNDLE_ID="${BUNDLE_ID:-com.shifterz.offnal}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-${TMPDIR:-/tmp}/offnal-ios-device-build}"
+METRO_PORT="${RCT_METRO_PORT:-${METRO_PORT:-8081}}"
+METRO_COMMAND="${ROOT_DIR}/scripts/start-metro.command"
+
+is_metro_running() {
+  lsof -nP -iTCP:"${METRO_PORT}" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+start_metro_if_needed() {
+  if is_metro_running; then
+    echo "Metro is already running on port ${METRO_PORT}"
+    return
+  fi
+
+  echo "Starting Metro in a new Terminal window"
+  chmod +x "${METRO_COMMAND}" 2>/dev/null || true
+  open -a Terminal "${METRO_COMMAND}"
+
+  for _ in {1..30}; do
+    if is_metro_running; then
+      echo "Metro is ready on port ${METRO_PORT}"
+      return
+    fi
+    sleep 1
+  done
+
+  echo "Metro did not report ready on port ${METRO_PORT}; continuing with the device build" >&2
+}
+
+if [[ -n "${DEVICE_ID}" ]]; then
+  XCODE_DESTINATION="id=${DEVICE_ID}"
+  DEVICE_SELECTOR="${DEVICE_ID}"
+else
+  XCODE_DESTINATION="generic/platform=iOS"
+  DEVICE_SELECTOR="${DEVICE_NAME}"
+fi
+
+start_metro_if_needed
+
+echo "Building ${SCHEME} (${CONFIGURATION}) for device ${DEVICE_SELECTOR}"
+ENVFILE="${ENVFILE_PATH}" xcodebuild \
+  -workspace "${WORKSPACE_PATH}" \
+  -scheme "${SCHEME}" \
+  -configuration "${CONFIGURATION}" \
+  -destination "${XCODE_DESTINATION}" \
+  -derivedDataPath "${DERIVED_DATA_PATH}" \
+  build
+
+APP_PATH="${DERIVED_DATA_PATH}/Build/Products/${CONFIGURATION}-iphoneos/Offnal.app"
+
+if [[ ! -d "${APP_PATH}" ]]; then
+  echo "Built app was not found at ${APP_PATH}" >&2
+  exit 1
+fi
+
+echo "Installing ${APP_PATH}"
+xcrun devicectl device install app --device "${DEVICE_SELECTOR}" "${APP_PATH}"
+
+echo "Launching ${BUNDLE_ID}"
+xcrun devicectl device process launch --device "${DEVICE_SELECTOR}" --terminate-existing "${BUNDLE_ID}"

--- a/scripts/start-metro.command
+++ b/scripts/start-metro.command
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "${ROOT_DIR}"
+npm start


### PR DESCRIPTION
## 개요

실제 iOS 기기에서 `npm run ios:dev` / `npm run ios:prod` 실행 시 빌드는 성공하지만 앱 설치 및 실행이 정상적으로 이어지지 않는 문제를 수정했습니다.

기존 React Native CLI의 `run-ios` 경로가 내부적으로 `ios-deploy`를 사용하면서 실제 기기를 안정적으로 인식하지 못하는 상황이 있었고, `devicectl`을 사용하는 실행 스크립트로 대체했습니다.

## 변경 사항

- `npm run ios:dev`, `npm run ios:prod` 명령어가 기존처럼 그대로 동작하도록 유지
- iOS 실제 기기 빌드/설치/실행을 `scripts/ios-device-run.sh`로 분리
- `xcodebuild`로 디바이스용 앱을 빌드한 뒤 `xcrun devicectl`로 설치 및 실행하도록 변경
- Metro dev server가 실행 중이 아니면 새 Terminal 창에서 자동으로 `npm start` 실행
- `DEVICE_ID`, `DEVICE_NAME`, `BUNDLE_ID`, `DERIVED_DATA_PATH`, `METRO_PORT` 환경변수로 로컬 실행 환경을 조정할 수 있도록 구성

## 원인

`react-native run-ios`는 빌드 이후 실제 기기 설치/실행 단계에서 `ios-deploy`를 사용합니다.  
현재 로컬 환경에서는 Xcode/CoreDevice 기준으로는 기기가 `available (paired)` 상태이고 `devicectl` 설치/실행도 가능하지만, `ios-deploy`가 동일 기기를 잡지 못해 앱 설치 및 실행이 누락되는 문제가 있었습니다.

## 검증

- `bash -n scripts/ios-device-run.sh`
- `bash -n scripts/start-metro.command`
- 실제 기기 인식 상태 확인
- `devicectl` 기반 앱 설치 및 실행 가능 여부 확인

## 참고

- `.env`, `.env.*`, `/env/*` 등 민감한 환경 파일은 읽거나 수정하지 않았습니다.
- `react-native-sqlite-storage`의 invalid configuration 경고와 Watchman recrawl 경고는 이번 실제 기기 설치 실패의 직접 원인은 아니며, 별도 정리 대상입니다.
