### PR TITLE
PR: [my-info][KanuKim97] : 내 정보화면 수정

### DIFF
--- a/src/presentation/info/components/InformationMenuContainer.tsx
+++ b/src/presentation/info/components/InformationMenuContainer.tsx
@@ -1,4 +1,5 @@
 import { TouchableOpacity, View } from 'react-native'
+import ChevronRightIcon from '../../../assets/icons/ic_chervon_right.svg'
 import GlobalText from '../../../shared/components/text/GlobalText'
 
 interface MenuProps {
@@ -8,7 +9,7 @@ interface MenuProps {
 
 const InformationMenuContainer = ({ menuTitle, menuItems }: MenuProps) => {
   return (
-    <View className="rounded-3xl bg-white py-number-3">
+    <View className="overflow-hidden rounded-radius-xl bg-surface-white py-number-5">
       <InformationMenuTitle title={menuTitle} />
       {menuItems.map(item => (
         <InformationMenuItem
@@ -30,7 +31,7 @@ type InformationMenuTitleProps = {
 const InformationMenuTitle = ({ title }: InformationMenuTitleProps) => {
   return (
     title && (
-      <GlobalText className="w-full px-number-8 py-[9px] font-pretMedium text-body-xxs">
+      <GlobalText className="w-full px-number-8 py-[9px] font-pretSemiBold text-heading-xxxs text-text-subtle">
         {title}
       </GlobalText>
     )
@@ -44,22 +45,22 @@ export interface MenuItemProps {
   onPress: () => void
 }
 
-const InformationMenuItem = ({
-  id: _id,
-  title,
-  caption,
-  onPress,
-}: MenuItemProps) => {
+const InformationMenuItem = ({ title, caption, onPress }: MenuItemProps) => {
   return (
     <TouchableOpacity
-      onPress={() => onPress()}
-      className="flex-row justify-between px-number-8 py-[9px]"
+      onPress={onPress}
+      activeOpacity={0.8}
+      className="flex-row items-center justify-between px-number-8 py-[10px]"
     >
-      <GlobalText className="font-pretMedium text-body-xs">{title}</GlobalText>
-      {caption && (
-        <GlobalText className="font-pretMedium text-body-xxs text-text-disabled">
+      <GlobalText className="font-pretMedium text-body-xxs text-text-subtle">
+        {title}
+      </GlobalText>
+      {caption ? (
+        <GlobalText className="font-pretRegular text-label-xxs text-text-disabled">
           {caption}
         </GlobalText>
+      ) : (
+        <ChevronRightIcon width={20} height={20} />
       )}
     </TouchableOpacity>
   )

--- a/src/presentation/info/components/InformationMenuContainer.tsx
+++ b/src/presentation/info/components/InformationMenuContainer.tsx
@@ -50,7 +50,7 @@ const InformationMenuItem = ({ title, caption, onPress }: MenuItemProps) => {
     <TouchableOpacity
       onPress={onPress}
       activeOpacity={0.8}
-      className="flex-row items-center justify-between px-number-8 py-[10px]"
+      className="flex-row items-center justify-between px-number-8 py-number-6"
     >
       <GlobalText className="font-pretMedium text-body-xxs text-text-subtle">
         {title}

--- a/src/presentation/info/components/MyInformationCard.tsx
+++ b/src/presentation/info/components/MyInformationCard.tsx
@@ -1,4 +1,5 @@
 import { Image, TouchableOpacity, View } from 'react-native'
+import ChevronRightIcon from '../../../assets/icons/ic_chervon_right.svg'
 import GlobalText from '../../../shared/components/text/GlobalText'
 
 type MyInformationCardProps = {
@@ -13,18 +14,24 @@ const MyInformationCard = ({
   onPressEditProfile,
 }: MyInformationCardProps) => {
   return (
-    <View className="flex-row items-center justify-between rounded-3xl bg-white px-number-6 py-number-6">
+    <TouchableOpacity
+      onPress={onPressEditProfile}
+      activeOpacity={0.8}
+      className="w-full flex-row items-center py-[10px]"
+    >
       <MyInformationImage profileImgUrl={profileImgUrl} />
-      <GlobalText className="flex-1 font-pretMedium text-body-s">
-        {profileName}
-      </GlobalText>
 
-      <TouchableOpacity onPress={onPressEditProfile}>
-        <GlobalText className="font-pretMedium text-body-xxs text-text-disabled">
+      <View className="flex-1">
+        <GlobalText className="font-pretMedium text-body-s text-text-basic">
+          {profileName}
+        </GlobalText>
+        <GlobalText className="mt-[2px] font-pretRegular text-label-xxs text-text-disabled">
           프로필 수정
         </GlobalText>
-      </TouchableOpacity>
-    </View>
+      </View>
+
+      <ChevronRightIcon width={20} height={20} />
+    </TouchableOpacity>
   )
 }
 
@@ -34,7 +41,7 @@ type MyInformationImageProps = {
 
 const MyInformationImage = ({ profileImgUrl }: MyInformationImageProps) => {
   return (
-    <View className="mr-3 h-number-12 w-number-12 items-center justify-center rounded-full bg-surface-gray-subtle2">
+    <View className="mr-[12px] h-number-12 w-number-12 items-center justify-center rounded-full bg-surface-gray-subtle2">
       <Image
         source={
           profileImgUrl

--- a/src/presentation/info/screen/InformationScreen.tsx
+++ b/src/presentation/info/screen/InformationScreen.tsx
@@ -1,4 +1,4 @@
-import { Alert, ScrollView, View } from 'react-native'
+import { ScrollView, View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import MyInformationCard from '../components/MyInformationCard'
 import InformationMenuContainer, {
@@ -104,8 +104,12 @@ const InformationScreen = () => {
   return (
     <View className="flex-1 bg-surface-gray-subtle1">
       <SafeAreaView className="flex-1" edges={['bottom']}>
-        <ScrollView className="flex-1 px-p-7">
-          <View className="flex-col gap-g-2">
+        <ScrollView
+          className="flex-1"
+          contentContainerClassName="px-p-7 pb-[32px] pt-[8px]"
+          showsVerticalScrollIndicator={false}
+        >
+          <View className="flex-col gap-g-3">
             <MyInformationCard
               profileName={user?.memberName ?? ''}
               profileImgUrl={user?.profileImageUrl ?? ''}
@@ -118,7 +122,7 @@ const InformationScreen = () => {
               menuItems={informationMenus}
             />
             <InformationMenuContainer
-              menuTitle="운영 방침"
+              menuTitle="운영방침"
               menuItems={termsOfUseMenus}
             />
             <InformationMenuContainer menuTitle="기타" menuItems={otherMenus} />

--- a/src/presentation/info/screen/InformationScreen.tsx
+++ b/src/presentation/info/screen/InformationScreen.tsx
@@ -106,7 +106,7 @@ const InformationScreen = () => {
       <SafeAreaView className="flex-1" edges={['bottom']}>
         <ScrollView
           className="flex-1"
-          contentContainerClassName="px-p-7 pb-[32px] pt-[8px]"
+          contentContainerClassName="px-p-7"
           showsVerticalScrollIndicator={false}
         >
           <View className="flex-col gap-g-3">


### PR DESCRIPTION
## Summary

내 정보 화면을 Figma 시안에 맞춰 정리했습니다.
카드/메뉴 영역의 간격, 타이포그래피, 컬러 토큰, 우측 chevron 아이콘 표현을 디자인 기준으로 맞추고, 프로필 영역의 클릭 동작도 카드 전체 기준으로 정리했습니다.

## Key Changes

- `src/presentation/info/components/MyInformationCard.tsx`
  - 프로필 영역 전체를 클릭 가능한 카드로 변경했습니다.
  - 이름/보조 텍스트 구조를 Figma 시안에 맞게 조정했습니다.
  - 우측 액션을 텍스트 버튼에서 chevron 아이콘으로 변경했습니다.
- `src/presentation/info/components/InformationMenuContainer.tsx`
  - 메뉴 섹션의 radius, padding, title typography, text color를 시안 기준으로 조정했습니다.
  - caption이 없는 항목에는 회색 chevron 아이콘이 노출되도록 변경했습니다.
  - `onPress={() => onPress()}` 형태를 직접 핸들러 전달로 정리했습니다.
- `src/presentation/info/screen/InformationScreen.tsx`
  - 스크롤 영역 padding / gap / bottom spacing을 시안 기준으로 조정했습니다.
  - 세로 스크롤 인디케이터를 숨겼습니다.
  - 메뉴 타이틀 `운영 방침`을 `운영방침`으로 정리했습니다.

## Test

- `npx eslint src/presentation/info/components/InformationMenuContainer.tsx src/presentation/info/components/MyInformationCard.tsx src/presentation/info/screen/InformationScreen.tsx`

## Notes

- 이번 변경은 내 정보 화면 UI 정렬 및 인터랙션 정리에 한정됩니다.
- `npm run check:changed`는 clean branch 상태에서 워킹트리 변경 파일이 없어 `No changed files found`로 종료되었습니다.
- 실제 디바이스/시뮬레이터 기준 시각 검증은 추가 확인이 필요합니다.

## Screenshots
<img width="585" height="1266" alt="스크린샷, 2026-05-13 오후 10 45 33" src="https://github.com/user-attachments/assets/1d0c047c-319a-4de6-8316-56f22c4bec8f" />

## Checklist

- [x] `main` 브랜치에 직접 푸시하지 않았습니다.
- [x] 변경 범위 기준 lint를 수행했습니다.
- [ ] 실제 디바이스/시뮬레이터에서 UI를 확인했습니다.
- [x] 변경 범위가 내 정보 화면 UI로 한정되는지 확인했습니다.
- [x] 의존성 변경이 없습니다.
