### PR TITLE
PR: [alert-dialog][KanuKim97] : 기본 Alert 다이얼로그 통일

### DIFF
--- a/src/presentation/info/screen/EditProfileScreen.tsx
+++ b/src/presentation/info/screen/EditProfileScreen.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useLayoutEffect, useState } from 'react'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import {
-  View,
-  Text,
-  TouchableOpacity,
-  TextInput,
-  Image,
-  Alert,
-} from 'react-native'
+import { View, Text, TouchableOpacity, TextInput, Image } from 'react-native'
 import GalleryIcon from '../../../assets/icons/ic_gallery_16_white.svg'
 import { useUserStore } from '../../../store/useUserStore'
 import { useNavigation } from '@react-navigation/native'
@@ -16,6 +9,7 @@ import { Asset, launchImageLibrary } from 'react-native-image-picker'
 import CenterAlignedTopAppBar from '../../../shared/components/appbar/CenterAlignedTopAppBar'
 import TopAppBarBackButton from '../../../shared/components/button/TopAppBarBackButton'
 import GlobalText from '../../../shared/components/text/GlobalText'
+import Dialog from '../../../shared/components/dialog/Dialog'
 
 const MAX_NAME_LENGTH = 10
 
@@ -28,6 +22,29 @@ const EditProfileScreen = () => {
   const [displayImgUrl, setDisplayImgUrl] = useState<string | null>(
     user?.profileImageUrl ?? null
   )
+  const [dialogState, setDialogState] = useState<{
+    visible: boolean
+    title: string
+    description: string
+    onConfirm?: () => void
+  }>({
+    visible: false,
+    title: '',
+    description: '',
+  })
+
+  const openDialog = (
+    title: string,
+    description: string,
+    onConfirm?: () => void
+  ) => {
+    setDialogState({
+      visible: true,
+      title,
+      description,
+      onConfirm,
+    })
+  }
 
   const handleChoosePhoto = async () => {
     launchImageLibrary({ mediaType: 'photo', quality: 1 }, response => {
@@ -35,7 +52,7 @@ const EditProfileScreen = () => {
         console.log('User cancelled image picker')
       } else if (response.errorCode) {
         console.log('ImagePicker Error: ', response.errorCode)
-        Alert.alert('오류', '이미지를 가져오는 데 실패했습니다.')
+        openDialog('오류', '이미지를 가져오는 데 실패했습니다.')
       } else if (response.assets && response.assets.length > 0) {
         const imageAsset = response.assets[0]
         setNewImage(imageAsset)
@@ -53,12 +70,12 @@ const EditProfileScreen = () => {
 
   const handleUpdateProfile = async () => {
     if (!user) {
-      Alert.alert('오류', '사용자 정보를 불러올 수 없습니다.')
+      openDialog('오류', '사용자 정보를 불러올 수 없습니다.')
       return
     }
 
     if (name.trim().length === 0) {
-      Alert.alert('오류', '이름을 입력해주세요.')
+      openDialog('오류', '이름을 입력해주세요.')
       return
     }
 
@@ -74,17 +91,12 @@ const EditProfileScreen = () => {
           : null
       )
 
-      Alert.alert('성공', '프로필이 수정되었습니다.', [
-        {
-          text: '확인',
-          onPress: () => {
-            navigation.goBack()
-          },
-        },
-      ])
+      openDialog('성공', '프로필이 수정되었습니다.', () => {
+        navigation.goBack()
+      })
     } catch (error) {
       console.error(error)
-      Alert.alert('오류', '프로필 수정에 실패했습니다.')
+      openDialog('오류', '프로필 수정에 실패했습니다.')
     }
   }
 
@@ -154,6 +166,21 @@ const EditProfileScreen = () => {
           </View>
         </View>
       </SafeAreaView>
+
+      <Dialog
+        visible={dialogState.visible}
+        title={dialogState.title}
+        description={dialogState.description}
+        onConfirm={() => {
+          const onConfirm = dialogState.onConfirm
+          setDialogState(prevState => ({
+            ...prevState,
+            visible: false,
+            onConfirm: undefined,
+          }))
+          onConfirm?.()
+        }}
+      />
     </View>
   )
 }

--- a/src/presentation/info/screen/EditProfileScreen.tsx
+++ b/src/presentation/info/screen/EditProfileScreen.tsx
@@ -172,13 +172,13 @@ const EditProfileScreen = () => {
         title={dialogState.title}
         description={dialogState.description}
         onConfirm={() => {
-          const onConfirm = dialogState.onConfirm
+          const confirmDialogAction = dialogState.onConfirm
           setDialogState(prevState => ({
             ...prevState,
             visible: false,
             onConfirm: undefined,
           }))
-          onConfirm?.()
+          confirmDialogAction?.()
         }}
       />
     </View>

--- a/src/presentation/info/screen/FeedBackScreen.tsx
+++ b/src/presentation/info/screen/FeedBackScreen.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,

--- a/src/presentation/info/screen/WithdrawBeforeScreen.tsx
+++ b/src/presentation/info/screen/WithdrawBeforeScreen.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Keyboard,
   KeyboardAvoidingView,
   Platform,
@@ -14,6 +13,7 @@ import { rootNavigation } from '../../../navigation/types/NavigationProps'
 import { useNavigation } from '@react-navigation/native'
 import { useState } from 'react'
 import EmphasizedButton from '../../../shared/components/button/Button'
+import Dialog from '../../../shared/components/dialog/Dialog'
 
 const WithdrawBeforeScreen = () => {
   const navigation = useNavigation<rootNavigation>()
@@ -25,6 +25,7 @@ const WithdrawBeforeScreen = () => {
     other: false,
   })
   const [otherReason, setOtherReason] = useState('')
+  const [isReasonDialogVisible, setIsReasonDialogVisible] = useState(false)
 
   const handleCheck = (key: keyof typeof checkedState) => {
     if (key === 'other' && checkedState.other) {
@@ -43,7 +44,7 @@ const WithdrawBeforeScreen = () => {
     if (isAnyChecked) {
       navigation.navigate('WithdrawScreen')
     } else {
-      Alert.alert('알림', '탈퇴 사유를 선택해주세요.')
+      setIsReasonDialogVisible(true)
     }
   }
 
@@ -114,6 +115,15 @@ const WithdrawBeforeScreen = () => {
             </View>
           </KeyboardAvoidingView>
         </SafeAreaView>
+
+        <Dialog
+          visible={isReasonDialogVisible}
+          title="알림"
+          description="탈퇴 사유를 선택해주세요."
+          onConfirm={() => {
+            setIsReasonDialogVisible(false)
+          }}
+        />
       </View>
     </TouchableWithoutFeedback>
   )

--- a/src/presentation/info/screen/WithdrawScreen.tsx
+++ b/src/presentation/info/screen/WithdrawScreen.tsx
@@ -1,5 +1,5 @@
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { ActivityIndicator, Alert, View } from 'react-native'
+import { ActivityIndicator, View } from 'react-native'
 import GlobalText from '../../../shared/components/text/GlobalText'
 import { rootNavigation } from '../../../navigation/types/NavigationProps'
 import { CommonActions, useNavigation } from '@react-navigation/native'

--- a/src/presentation/login/screen/LoginScreen.tsx
+++ b/src/presentation/login/screen/LoginScreen.tsx
@@ -1,12 +1,6 @@
 import { useState } from 'react'
 import Swiper from 'react-native-swiper'
-import {
-  View,
-  Dimensions,
-  TouchableOpacity,
-  Platform,
-  Alert,
-} from 'react-native'
+import { View, Dimensions, TouchableOpacity, Platform } from 'react-native'
 import {
   useNavigation,
   CompositeNavigationProp,
@@ -24,6 +18,7 @@ import appleAuth, {
   AppleButton,
 } from '@invertase/react-native-apple-authentication'
 import { useAuthStore } from '../../../store/useAuthStore'
+import Dialog from '../../../shared/components/dialog/Dialog'
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window')
 
@@ -38,6 +33,7 @@ const LoginScreen = () => {
   const loginWithApple = useAuthStore(state => state.loginWithApple)
   const loginWithKakao = useAuthStore(state => state.loginWithKakao)
   const [isKakaoLoading, setIsKakaoLoading] = useState(false)
+  const [loginErrorMessage, setLoginErrorMessage] = useState('')
 
   const navigateAfterSocialLogin = (isNewMember: boolean) => {
     navigation.getParent<rootNavigation>()?.reset({
@@ -149,7 +145,7 @@ const LoginScreen = () => {
                 return
               }
 
-              Alert.alert('로그인 실패', getKakaoLoginErrorMessage(error))
+              setLoginErrorMessage(getKakaoLoginErrorMessage(error))
             }
           }}
         />
@@ -173,8 +169,7 @@ const LoginScreen = () => {
                   return
                 }
 
-                Alert.alert(
-                  '로그인 실패',
+                setLoginErrorMessage(
                   '로그인에 실패했습니다. 다시 시도해주세요.'
                 )
               }
@@ -215,6 +210,15 @@ const LoginScreen = () => {
           </GlobalText>
         </View>
       </View>
+
+      <Dialog
+        visible={Boolean(loginErrorMessage)}
+        title="로그인 실패"
+        description={loginErrorMessage}
+        onConfirm={() => {
+          setLoginErrorMessage('')
+        }}
+      />
     </SafeAreaView>
   )
 }

--- a/src/presentation/note/screens/AddMemoScreen.tsx
+++ b/src/presentation/note/screens/AddMemoScreen.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   TextInput,
@@ -16,6 +15,7 @@ import { rootNavigation } from '../../../navigation/types/NavigationProps'
 import { RootStackParamList } from '../../../navigation/types/RootStackParamList'
 import dayjs from 'dayjs'
 import { useMemoStore } from '../../../store/useMemoStore'
+import Dialog from '../../../shared/components/dialog/Dialog'
 
 const AddMemoScreenTopAppBar = ({
   onBack,
@@ -57,12 +57,25 @@ const AddMemoScreen = () => {
 
   const [title, setTitle] = useState(memoToUpdate?.title || '')
   const [content, setContent] = useState(memoToUpdate?.content || '')
+  const [dialogState, setDialogState] = useState({
+    visible: false,
+    title: '',
+    description: '',
+  })
 
   const isDisabled = !title.trim()
 
+  const openDialog = (dialogTitle: string, description: string) => {
+    setDialogState({
+      visible: true,
+      title: dialogTitle,
+      description,
+    })
+  }
+
   const handleSave = async () => {
     if (isDisabled) {
-      Alert.alert('알림', '제목을 모두 입력해주세요.')
+      openDialog('알림', '제목을 모두 입력해주세요.')
       return
     }
 
@@ -81,7 +94,7 @@ const AddMemoScreen = () => {
       }
     } catch (error) {
       console.error('Error saving memo:', error)
-      Alert.alert('오류', '메모 생성에 실패했습니다.')
+      openDialog('오류', '메모 생성에 실패했습니다.')
     }
   }
 
@@ -127,6 +140,18 @@ const AddMemoScreen = () => {
             textAlignVertical="top"
           />
         </KeyboardAvoidingView>
+
+        <Dialog
+          visible={dialogState.visible}
+          title={dialogState.title}
+          description={dialogState.description}
+          onConfirm={() => {
+            setDialogState(prevState => ({
+              ...prevState,
+              visible: false,
+            }))
+          }}
+        />
       </SafeAreaView>
     </View>
   )

--- a/src/presentation/note/screens/MemoScreen.tsx
+++ b/src/presentation/note/screens/MemoScreen.tsx
@@ -145,8 +145,14 @@ const MemoScreen = () => {
         }}
         onConfirm={async () => {
           if (memoToDeleteId === null) return
-          await deleteMemo(memoToDeleteId)
-          setMemoToDeleteId(null)
+
+          try {
+            await deleteMemo(memoToDeleteId)
+          } catch (error) {
+            console.error('Error deleting memo: ', error)
+          } finally {
+            setMemoToDeleteId(null)
+          }
         }}
       />
     </View>

--- a/src/presentation/note/screens/MemoScreen.tsx
+++ b/src/presentation/note/screens/MemoScreen.tsx
@@ -1,5 +1,5 @@
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { View, TouchableOpacity, Alert, ScrollView } from 'react-native'
+import { View, TouchableOpacity, ScrollView } from 'react-native'
 import { SwipeListView } from 'react-native-swipe-list-view'
 import DayBoxHeader from '../components/DayBoxHeader'
 import dayjs from 'dayjs'
@@ -20,6 +20,7 @@ import { useMemoStore } from '../../../store/useMemoStore'
 import { rootNavigation } from '../../../navigation/types/NavigationProps'
 import { RootStackParamList } from '../../../navigation/types/RootStackParamList'
 import AddOneTouchableChip from '../../../shared/components/chip/AddOneTouchableChip'
+import ConfirmDialog from '../../../shared/components/dialog/ConfirmDialog'
 
 const MemoScreen = () => {
   const navigation = useNavigation<rootNavigation>()
@@ -38,6 +39,7 @@ const MemoScreen = () => {
   )
 
   const [currentDate, setCurrentDate] = useState(selectedDate ?? dayjs())
+  const [memoToDeleteId, setMemoToDeleteId] = useState<number | null>(null)
 
   useEffect(() => {
     fetchMemosByDate(currentDate)
@@ -50,14 +52,7 @@ const MemoScreen = () => {
   )
 
   const handleDelete = (id: number) => {
-    Alert.alert('메모 삭제', '정말로 이 메모를 삭제하시겠습니까?', [
-      { text: '취소', style: 'cancel' },
-      {
-        text: '삭제',
-        onPress: () => deleteMemo(id),
-        style: 'destructive',
-      },
-    ])
+    setMemoToDeleteId(id)
   }
 
   return (
@@ -138,6 +133,22 @@ const MemoScreen = () => {
           </View>
         </ScrollView>
       </SafeAreaView>
+
+      <ConfirmDialog
+        visible={memoToDeleteId !== null}
+        title="메모 삭제"
+        description="정말로 이 메모를 삭제하시겠습니까?"
+        cancelText="취소"
+        confirmText="삭제"
+        onCancel={() => {
+          setMemoToDeleteId(null)
+        }}
+        onConfirm={async () => {
+          if (memoToDeleteId === null) return
+          await deleteMemo(memoToDeleteId)
+          setMemoToDeleteId(null)
+        }}
+      />
     </View>
   )
 }

--- a/src/presentation/note/screens/TodoScreen.tsx
+++ b/src/presentation/note/screens/TodoScreen.tsx
@@ -1,6 +1,5 @@
 import React, { Fragment, useEffect, useRef, useState } from 'react'
 import {
-  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -28,6 +27,7 @@ import { RootStackParamList } from '../../../navigation/types/RootStackParamList
 import { RouteProp, useRoute } from '@react-navigation/native'
 import { useHeaderHeight } from '@react-navigation/elements'
 import { useShallow } from 'zustand/shallow'
+import Dialog from '../../../shared/components/dialog/Dialog'
 
 const TodoScreen = () => {
   const route = useRoute<RouteProp<RootStackParamList, 'Todo'>>()
@@ -57,6 +57,7 @@ const TodoScreen = () => {
   const [todo, setTodo] = useState('')
   const [selectedTodo, setSelectedTodo] = useState<Todo | null>(null)
   const [showInput, setShowInput] = useState(false)
+  const [isTodoDialogVisible, setIsTodoDialogVisible] = useState(false)
 
   const [currentDate, setCurrentDate] = useState(selectedDate ?? dayjs())
 
@@ -93,7 +94,7 @@ const TodoScreen = () => {
 
   const handleAddTodo = async () => {
     if (!todo.trim()) {
-      Alert.alert('알림', '할 일 내용을 압력해주세요')
+      setIsTodoDialogVisible(true)
       return
     }
 
@@ -317,6 +318,15 @@ const TodoScreen = () => {
 
           await scheduleByDate(selectedTodo, targetDate, currentDate)
           changeTodoDateBottomSheetRef.current?.close()
+        }}
+      />
+
+      <Dialog
+        visible={isTodoDialogVisible}
+        title="알림"
+        description="할 일 내용을 압력해주세요"
+        onConfirm={() => {
+          setIsTodoDialogVisible(false)
         }}
       />
     </View>

--- a/src/presentation/note/screens/TodoScreen.tsx
+++ b/src/presentation/note/screens/TodoScreen.tsx
@@ -324,7 +324,7 @@ const TodoScreen = () => {
       <Dialog
         visible={isTodoDialogVisible}
         title="알림"
-        description="할 일 내용을 압력해주세요"
+        description="할 일 내용을 입력해주세요"
         onConfirm={() => {
           setIsTodoDialogVisible(false)
         }}

--- a/src/presentation/onboarding/screens/InputScheduleScreen.tsx
+++ b/src/presentation/onboarding/screens/InputScheduleScreen.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react'
-import { Alert, View } from 'react-native'
+import React, { useEffect, useState } from 'react'
+import { View } from 'react-native'
 import TimeInput from '../component/TimeInput'
 import TeamInput from '../component/TeamInput'
 import ScheduleNameInput from '../component/ScheduleNameInput'
@@ -14,12 +14,14 @@ import { OnboardingRoute } from '../../../navigation/types/OnboardingRoute'
 import { useShallow } from 'zustand/shallow'
 import EmphasizedButton from '../../../shared/components/button/Button'
 import GlobalText from '../../../shared/components/text/GlobalText'
+import Dialog from '../../../shared/components/dialog/Dialog'
 
 const InputScheduleScreen = () => {
   const navigation = useNavigation<{
     navigate: (route: OnboardingRoute) => void
   }>()
   const onboardingMethod = useOnboardingStore(state => state.onboardingMethod)
+  const [isNameDialogVisible, setIsNameDialogVisible] = useState(false)
   const {
     organizationName = '',
     setOrganizationName,
@@ -38,7 +40,7 @@ const InputScheduleScreen = () => {
 
   const handleNext = async () => {
     if (organizationName.trim() === '') {
-      Alert.alert('근무표 이름을 입력해주세요.')
+      setIsNameDialogVisible(true)
       return
     }
 
@@ -75,6 +77,15 @@ const InputScheduleScreen = () => {
           </GlobalText>
         }
         onPress={handleNext}
+      />
+
+      <Dialog
+        visible={isNameDialogVisible}
+        title="알림"
+        description="근무표 이름을 입력해주세요."
+        onConfirm={() => {
+          setIsNameDialogVisible(false)
+        }}
       />
     </SafeAreaView>
   )

--- a/src/presentation/onboarding/screens/ocr/SelectMonthOCRScreen.tsx
+++ b/src/presentation/onboarding/screens/ocr/SelectMonthOCRScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react'
-import { View, Alert } from 'react-native'
+import { View } from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { MonthPicker } from '../../component/MonthPicker'
 import { useNavigation } from '@react-navigation/native'
@@ -10,6 +10,7 @@ import { OnboardingStep } from '../../types/onboardingTypes'
 import { OnboardingRoute } from '../../../../navigation/types/OnboardingRoute'
 import GlobalText from '../../../../shared/components/text/GlobalText'
 import EmphasizedButton from '../../../../shared/components/button/Button'
+import Dialog from '../../../../shared/components/dialog/Dialog'
 
 const SelectMonthOCRScreen = () => {
   const navigation = useNavigation<{
@@ -21,6 +22,7 @@ const SelectMonthOCRScreen = () => {
     year: new Date().getFullYear(),
     month: null,
   })
+  const [isMonthDialogVisible, setIsMonthDialogVisible] = useState(false)
 
   const handleDateChange = useCallback((year: number, month: number | null) => {
     setDate({ year, month })
@@ -40,11 +42,7 @@ const SelectMonthOCRScreen = () => {
         },
       } as OnboardingRoute)
     } else {
-      Alert.alert(
-        '월을 선택해주세요',
-        '근무 월을 선택하지 않으면 다음 단계로 넘어갈 수 없습니다.',
-        [{ text: '확인', onPress: () => {} }]
-      )
+      setIsMonthDialogVisible(true)
     }
   }
 
@@ -66,6 +64,15 @@ const SelectMonthOCRScreen = () => {
             </GlobalText>
           }
           onPress={handleNext}
+        />
+
+        <Dialog
+          visible={isMonthDialogVisible}
+          title="월을 선택해주세요"
+          description="근무 월을 선택하지 않으면 다음 단계로 넘어갈 수 없습니다."
+          onConfirm={() => {
+            setIsMonthDialogVisible(false)
+          }}
         />
       </SafeAreaView>
     </View>

--- a/src/shared/components/calendar/personal/CalendarEditor.tsx
+++ b/src/shared/components/calendar/personal/CalendarEditor.tsx
@@ -15,13 +15,14 @@ import { calendarRepository } from '../../../../infrastructure/di/Dependencies'
 import { CreateCalendarRequest } from '../../../../infrastructure/remote/request/CreateWorkCalendarRequest'
 import { WorkType } from '../../../types/Calendar'
 import { useCalendarStore } from '../../../../store/useCalendarStore'
-import { Alert, View } from 'react-native'
+import { View } from 'react-native'
 import TypeSelect from './TypeSelect'
 import { fromShiftType } from '../../../../data/mappers/ShiftTypeMapper'
 import { convertEndTimeToDuration } from '../../../utils/calendar/convertDuration'
 import { useScheduleInfoStore } from '../../../../store/useScheduleInfoStore'
 import { useOnboardingStore } from '../../../../store/useOnboardingStore'
 import { useShallow } from 'zustand/shallow'
+import Dialog from '../../dialog/Dialog'
 
 export interface CalendarEditorRef {
   postData: () => Promise<boolean>
@@ -101,6 +102,8 @@ const CalendarEditor: ForwardRefRenderFunction<
     E: { startTime: '16:00', duration: 'PT8H' },
     N: { startTime: '00:00', duration: 'PT8H' },
   })
+  const [isValidationDialogVisible, setIsValidationDialogVisible] =
+    useState(false)
 
   // workTimes 에서 endTime -> duration 변환
   useEffect(() => {
@@ -119,7 +122,7 @@ const CalendarEditor: ForwardRefRenderFunction<
       const hasAnyWorkData = Object.keys(allCalendarData).length > 0
 
       if (!hasAnyWorkData) {
-        Alert.alert('알림', '근무 형태를 하나 이상 입력해주세요.')
+        setIsValidationDialogVisible(true)
         return false
       }
       try {
@@ -172,6 +175,14 @@ const CalendarEditor: ForwardRefRenderFunction<
         calendarData={allCalendarData}
       />
       <TypeSelect onPress={handleTypeSelect} />
+      <Dialog
+        visible={isValidationDialogVisible}
+        title="알림"
+        description="근무 형태를 하나 이상 입력해주세요."
+        onConfirm={() => {
+          setIsValidationDialogVisible(false)
+        }}
+      />
     </View>
   )
 }

--- a/src/shared/components/calendar/team/TCalendarEditor.tsx
+++ b/src/shared/components/calendar/team/TCalendarEditor.tsx
@@ -5,7 +5,7 @@ import React, {
   ForwardRefRenderFunction,
   forwardRef,
 } from 'react'
-import { Alert, View } from 'react-native'
+import { View } from 'react-native'
 import dayjs from 'dayjs'
 import TCalendarBase from './TCalendarBase'
 import TeamTypeSelect from './TeamTypeSelect'
@@ -23,6 +23,7 @@ import { useOnboardingStore } from '../../../../store/useOnboardingStore'
 import { mergeTeamCalendars } from '../../../utils/calendar/mergeTeamCalendars'
 import { UpdateTeamShiftsRequest } from '../../../../infrastructure/remote/request/PatchTeamWorkCalendarRequest'
 import { useShallow } from 'zustand/shallow'
+import Dialog from '../../dialog/Dialog'
 
 export interface TCalendarEditorRef {
   postData: () => Promise<boolean>
@@ -36,6 +37,8 @@ const TCalendarEditor: ForwardRefRenderFunction<
   }
 > = ({ currentDate, myTeam }, ref) => {
   const [selectedDate, setSelectedDate] = useState<dayjs.Dayjs | null>(null)
+  const [isValidationDialogVisible, setIsValidationDialogVisible] =
+    useState(false)
 
   const {
     teamCalendarData,
@@ -121,7 +124,7 @@ const TCalendarEditor: ForwardRefRenderFunction<
         teamRecord => Object.keys(teamRecord.workInstances).length > 0
       )
       if (!hasAnyWorkData) {
-        Alert.alert('알림', '근무 형태를 하나 이상 입력해주세요.')
+        setIsValidationDialogVisible(true)
         return false
       }
       try {
@@ -188,6 +191,14 @@ const TCalendarEditor: ForwardRefRenderFunction<
         myTeam={myTeam}
       />
       <TeamTypeSelect onPressSelect={handleTypeSelect} />
+      <Dialog
+        visible={isValidationDialogVisible}
+        title="알림"
+        description="근무 형태를 하나 이상 입력해주세요."
+        onConfirm={() => {
+          setIsValidationDialogVisible(false)
+        }}
+      />
     </View>
   )
 }


### PR DESCRIPTION
## Summary

앱 전반에서 사용하던 시스템 `Alert.alert`를 공통 커스텀 다이얼로그 디자인으로 통일했습니다.
단순 안내/검증성 알림은 `Dialog`, 삭제 확인은 `ConfirmDialog`로 치환해 사용자 경험을 일관되게 맞췄고, 로그인 실패나 프로필 수정 완료처럼 후속 동작이 필요한 케이스도 기존 흐름을 유지하도록 정리했습니다.

## Key Changes

- 온보딩, 메모/할 일, 탈퇴 전 안내, 개인/팀 캘린더 저장 검증 등 단순 알림을 `Dialog` 기반 로컬 상태로 통일했습니다.
- 로그인 화면의 카카오/애플 로그인 실패를 시스템 Alert 대신 공통 `Dialog`로 표시하도록 변경했습니다.
- 프로필 수정 화면에서 이미지 선택 실패, 유저 정보 없음, 이름 미입력, 수정 성공/실패를 모두 `Dialog`로 관리하고, 성공 확인 후 `goBack()` 동작을 유지했습니다.
- 메모 삭제는 시스템 Alert 대신 `ConfirmDialog`를 사용하도록 변경해 삭제 확인 UI를 기존 커스텀 다이얼로그 체계에 맞췄습니다.
- 더 이상 사용하지 않는 `Alert` import를 함께 정리했습니다.

## Test

- `npm run lint`
- `npm test -- --watchman=false --passWithNoTests`

## Notes

- `src` 기준 기존 `Alert.alert` 사용처는 이번 변경 범위에서 모두 제거했습니다.
- `npm run check:changed`는 Jest 실행 단계에서 로컬 watchman 소켓 접근 제한으로 중단되어, 동일 테스트를 `--watchman=false`로 우회 실행해 통과 여부를 확인했습니다.
- 이번 PR은 다이얼로그 통일과 미사용 import 정리에 한정되며, 전역 다이얼로그 서비스나 공통 훅 추가는 포함하지 않았습니다.

## Checklist

- [x] `main` 브랜치에 직접 푸시하지 않았습니다.
- [x] 변경 범위 기준 lint를 수행했습니다.
- [x] Jest를 `--watchman=false`로 실행해 테스트 통과를 확인했습니다.
- [x] 실제 디바이스/시뮬레이터에서 주요 알림 플로우를 확인했습니다.
- [x] 변경 범위가 Alert -> Dialog/ConfirmDialog 통일로 한정되는지 확인했습니다.
- [x] 의존성 변경이 없습니다.
